### PR TITLE
global: fix import of invenio_upgrader

### DIFF
--- a/invenio_oauthclient/upgrades/oauthclient_2014_03_02_initial.py
+++ b/invenio_oauthclient/upgrades/oauthclient_2014_03_02_initial.py
@@ -20,7 +20,7 @@
 import warnings
 from sqlalchemy import *
 from invenio.ext.sqlalchemy import db
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 depends_on = []
 

--- a/invenio_oauthclient/upgrades/oauthclient_2014_04_14_json_type_fix.py
+++ b/invenio_oauthclient/upgrades/oauthclient_2014_04_14_json_type_fix.py
@@ -17,7 +17,7 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 from sqlalchemy.dialects import mysql
 
 depends_on = [u'oauthclient_2014_03_02_initial']

--- a/invenio_oauthclient/upgrades/oauthclient_2014_08_25_extra_data_nullable.py
+++ b/invenio_oauthclient/upgrades/oauthclient_2014_08_25_extra_data_nullable.py
@@ -18,7 +18,7 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 from sqlalchemy.dialects import mysql
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 
 depends_on = ['oauthclient_2014_04_14_json_type_fix']

--- a/invenio_oauthclient/upgrades/oauthclient_2014_10_21_encrypted_token_column.py
+++ b/invenio_oauthclient/upgrades/oauthclient_2014_10_21_encrypted_token_column.py
@@ -18,7 +18,7 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 from invenio.legacy.dbquery import run_sql
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 
 depends_on = [u'oauthclient_2014_08_25_extra_data_nullable']

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ requirements = [
     # FIXME new oauthlib release after 0.7.2 has some compatible problems with
     # the used Flask-Oauthlib version.
     'oauthlib==0.7.2',
+    'invenio-upgrader>=0.1.0',
 ]
 
 test_requirements = [


### PR DESCRIPTION
* FIX Fixes import of invenio_upgrader in the past upgrade recipes
  following its separation into standalone package.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>