### PR TITLE
contrib: removal of dependency on Invenio-Groups

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -61,6 +61,12 @@ Forms
 .. automodule:: invenio_oauthclient.forms
    :members:
 
+Signals
+-------
+
+.. automodule:: invenio_oauthclient.signals
+   :members:
+
 Utils
 -----
 

--- a/invenio_oauthclient/contrib/cern.py
+++ b/invenio_oauthclient/contrib/cern.py
@@ -86,9 +86,7 @@ In templates you can add a sign in/up link:
 import copy
 import re
 
-import requests
 from flask import current_app
-from flask_login import current_user
 
 #: Tunable list of groups to be hidden.
 CFG_EXTERNAL_AUTH_HIDDEN_GROUPS = (
@@ -201,22 +199,6 @@ def account_info(remote, resp):
     return dict(email=email.lower(), nickname=common_name)
 
 
-def account_setup(remote, token):
+def account_setup(remote, token, resp):
     """Perform additional setup after user have been logged in."""
-    from invenio_db import db
-
-    response = remote.get(REMOTE_APP_RESOURCE_API_URL)
-    user = token.remote_account.user
-
-    if response.status == requests.codes.ok:
-        res = get_dict_from_response(response)
-        current_user.info['group'] = fetch_groups(res['Group'])
-        current_user.modified = True
-        current_user.save()
-
-        if user and not any([user.family_name, user.given_names]):
-            user.family_name = res['Lastname'][0]
-            user.given_names = res['Firstname'][0]
-
-            db.session.add(user)
-            current_user.reload()
+    pass

--- a/invenio_oauthclient/contrib/github.py
+++ b/invenio_oauthclient/contrib/github.py
@@ -120,6 +120,6 @@ def account_info(remote, resp):
                 external_method='github')
 
 
-def account_setup(remote, token):
+def account_setup(remote, token, resp):
     """Perform additional setup after user have been logged in."""
     pass

--- a/invenio_oauthclient/signals.py
+++ b/invenio_oauthclient/signals.py
@@ -38,10 +38,27 @@ Example subscriber:
     from invenio_oauthclient.signals import account_info_received
 
     # During overlay initialization.
-    @account_info_received.connect_via(
-        sender=app.extensions['invenio-oauthclient'].handlers['orcid']
-    )
-    def load_extra_information(remote, response=None, account_info=None):
+    @account_info_received.connect
+    def load_extra_information(remote, token=None, response=None,
+                               account_info=None):
+        response = remote.get('https://example.org/api/resource')
+        # process response
+
+"""
+
+account_setup_received = _signals.signal('oauthclient-account-setup-received')
+"""Signal is sent after account info handler response.
+
+Example subscriber:
+
+.. code-block:: python
+
+    from invenio_oauthclient.signals import account_setup_received
+
+    # During overlay initialization.
+    @account_setup_received.connect
+    def load_extra_information(remote, token=None, response=None,
+                               account_setup=None):
         response = remote.get('https://example.org/api/resource')
         # process response
 

--- a/invenio_oauthclient/signals.py
+++ b/invenio_oauthclient/signals.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Signals used together with various handlers."""
+
+from blinker import Namespace
+
+_signals = Namespace()
+
+account_info_received = _signals.signal('oauthclient-account-info-received')
+"""Signal is sent after account info handler response.
+
+Example subscriber:
+
+.. code-block:: python
+
+    from invenio_oauthclient.signals import account_info_received
+
+    # During overlay initialization.
+    @account_info_received.connect_via(
+        sender=app.extensions['invenio-oauthclient'].handlers['orcid']
+    )
+    def load_extra_information(remote, response=None, account_info=None):
+        response = remote.get('https://example.org/api/resource')
+        # process response
+
+"""

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup_requires = [
 ]
 
 install_requires = [
+    'blinker>=1.4',
     'cryptography>=0.6',  # sqlalchemy-utils dependency
     'Flask>=0.10.1',
     'Flask-BabelEx>=0.9.2',


### PR DESCRIPTION
* Removes the dependency on Invenio-Groups reducing the number of fields
  parsed inside CERN or ORCID modules and sending the response to a
  subscribable signal. (closes #18)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>