### PR TITLE
ext: fix init without oauthlib.client extension

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -47,6 +47,11 @@ def test_init():
 
     app = Flask('testapp')
     FlaskCLI(app)
+    ext = InvenioOAuthClient(app)
+    assert 'invenio-oauthclient' in app.extensions
+
+    app = Flask('testapp')
+    FlaskCLI(app)
     FlaskOAuth(app)
     ext = InvenioOAuthClient()
     assert 'invenio-oauthclient' not in app.extensions


### PR DESCRIPTION
* Fixes the initialization of the extension when there is no
oauthlib.client object in extensions.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>