### PR TITLE
installation: HTTPretty==0.8.10 version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ tests_require = [
     'Flask-CLI>=0.2.1',
     'check-manifest>=0.25',
     'coverage>=4.0',
-    'httpretty>=0.8.10',
+    'httpretty==0.8.10',  # see gabrielfalcao/HTTPretty#269
     'isort>=4.2.2',
     'mock>=1.3.0',
     'pep257>=0.7.0',


### PR DESCRIPTION
* Pins HTTPretty version to 0.8.10 due to broken compatibility with
  Python 3.  (addresses gabrielfalcao/HTTPretty#269)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>

--
or we should wait for https://github.com/gabrielfalcao/HTTPretty/pull/277