### PR TITLE
templates: addition of OAuth login buttons macro

### DIFF
--- a/invenio_oauthclient/ext.py
+++ b/invenio_oauthclient/ext.py
@@ -127,3 +127,7 @@ class InvenioOAuthClient(object):
         for k in dir(config):
             if k.startswith('OAUTHCLIENT_'):
                 app.config.setdefault(k, getattr(config, k))
+
+        app.config.update(
+            SECURITY_LOGIN_USER_TEMPLATE="invenio_oauthclient/login_user.html"
+        )

--- a/invenio_oauthclient/templates/invenio_oauthclient/_macros.html
+++ b/invenio_oauthclient/templates/invenio_oauthclient/_macros.html
@@ -48,3 +48,13 @@
   </div>
   {%- endif %}
 {% endmacro %}
+
+
+{% macro oauth_button(name) %}
+  {# TODO add next argument except when security.login or logout #}
+  <a class="btn btn-default btn-lg btn-block"
+     href="{{url_for('invenio_oauthclient.login', remote_app=name)}}">
+    <i class="fa fa-{{ name|lower() }}"></i> {{ _('Sign in with %(title)s',
+                                                   title=config.OAUTHCLIENT_REMOTE_APPS[name]['title']) }}
+  </a>
+{% endmacro %}

--- a/invenio_oauthclient/templates/invenio_oauthclient/login_user.html
+++ b/invenio_oauthclient/templates/invenio_oauthclient/login_user.html
@@ -1,0 +1,37 @@
+{# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+#}
+{%- extends "invenio_accounts/login_user.html" %}
+
+{% from "invenio_oauthclient/_macros.html" import oauth_button %}
+
+{% block form_outer %}
+  {% if config.OAUTHCLIENT_REMOTE_APPS %}
+    {% for name in config.OAUTHCLIENT_REMOTE_APPS.keys() %}
+      {{ oauth_button(name) }}
+    {% endfor %}
+    <h3 align="center">&mdash; OR &mdash;</h3>
+  {% endif %}
+  {{ super () }}
+{% endblock %}


### PR DESCRIPTION
* Adds a macro to generate the links to connect with the installed
  OAuth services.

* Adds a login_user.html template with the form showing the
  OAuth services to login and the fields to a regular login.
  (closes #26)

Co-Authored-By: Jiri Kuncar <jiri.kuncar@cern.ch>
Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>