### PR TITLE
global: new configurable OAuthRemoteApp factory

### DIFF
--- a/invenio_oauthclient/config.py
+++ b/invenio_oauthclient/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -26,6 +26,7 @@
                                  an access token. **Default:** ``oauth_token``.
 `OAUTHCLIENT_STATE_EXPIRES`      Number of seconds after which the state token
                                  expires. Defaults to 300 seconds.
+`OAUTHCLIENT_REMOTE_APP`         Replaces the default remote application class.
 ================================ ==============================================
 
 Each remote application must be defined in the ``OAUTHCLIENT_REMOTE_APPS``
@@ -174,6 +175,39 @@ a given authorize request.
             # ...
         )
     )
+
+Custom remote application
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some OAuth services require a specific handling of OAuth requests. If the
+standard flask-oauthlib.client.OAuthRemoteApp does not support it, it is
+possible to replace the standard OAuthRemoteApp for all remote application
+by referring to the custom class with the configuration variable
+``OAUTHCLIENT_REMOTE_APP`` or for only one remote application by
+setting ``remote_app`` in your remote application configuration.
+
+.. code-block:: python
+
+    class CustomOAuthRemoteApp(OAuthRemoteApp):
+        pass
+
+    app.config.update(
+        OAUTHCLIENT_REMOTE_APP=
+            'myproject.mymodule:CustomOAuthRemoteApp'
+    )
+
+    # OR
+
+    app.config.update(
+        OAUTHCLIENT_REMOTE_APPS=dict(
+            custom_app=dict(
+                # ...
+                remote_app=
+                    'myproject.mymodule:CustomOAuthRemoteApp'
+            )
+        )
+    )
+
 """
 
 OAUTHCLIENT_REMOTE_APPS = {}

--- a/invenio_oauthclient/utils.py
+++ b/invenio_oauthclient/utils.py
@@ -19,6 +19,7 @@
 
 """Utility methods to help find, authenticate or register a remote user."""
 
+import six
 from flask import after_this_request, current_app, request
 from flask_security import login_user, logout_user
 from flask_security.confirmable import requires_confirmation
@@ -27,6 +28,7 @@ from invenio_accounts.models import User
 from invenio_db import db
 from uritools import urisplit
 from werkzeug.local import LocalProxy
+from werkzeug.utils import import_string
 
 from .models import RemoteAccount, RemoteToken, UserIdentity
 
@@ -131,3 +133,19 @@ def get_safe_redirect_target(arg='next'):
         if target and is_local_url(target):
             return target
     return None
+
+
+def obj_or_import_string(value, default=None):
+    """Import string or return object."""
+    if isinstance(value, six.string_types):
+        return import_string(value)
+    elif value:
+        return value
+    return default
+
+
+def load_or_import_from_config(key, app=None, default=None):
+    """Load or import value from config."""
+    app = app or current_app
+    imp = app.config.get(key)
+    return obj_or_import_string(imp, default=default)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,15 +22,17 @@
 from __future__ import absolute_import
 
 import os
+from copy import deepcopy
 
 from flask import Flask
 from flask_cli import FlaskCLI
 from flask_oauthlib.client import OAuth as FlaskOAuth
+from flask_oauthlib.client import OAuthRemoteApp
 from invenio_db import InvenioDB, db
-from sqlalchemy_utils.functions import create_database, database_exists, \
-    drop_database
+from sqlalchemy_utils.functions import create_database, database_exists
 
 from invenio_oauthclient import InvenioOAuthClient
+from invenio_oauthclient.contrib.orcid import REMOTE_APP
 
 
 def test_version():
@@ -59,6 +61,58 @@ def test_init():
     assert 'invenio-oauthclient' not in app.extensions
     ext.init_app(app)
     assert 'invenio-oauthclient' in app.extensions
+
+
+class _CustomOAuthRemoteApp(OAuthRemoteApp):
+    """Custom OAuthRemoteApp used for testing."""
+
+
+def test_standard_remote_app_factory(base_app):
+    """Test standard remote_app class."""
+    base_app.config.update(
+        OAUTHCLIENT_REMOTE_APPS=dict(
+            custom_app=REMOTE_APP
+        )
+    )
+    FlaskOAuth(base_app)
+    InvenioOAuthClient(base_app)
+    assert isinstance(
+        base_app.extensions['oauthlib.client'].remote_apps['custom_app'],
+        OAuthRemoteApp)
+    assert not isinstance(
+        base_app.extensions['oauthlib.client'].remote_apps['custom_app'],
+        _CustomOAuthRemoteApp)
+
+
+def test_remote_app_factory_global_customization(base_app):
+    """Test remote_app override with global variable."""
+    base_app.config.update(
+        OAUTHCLIENT_REMOTE_APP=_CustomOAuthRemoteApp,
+        OAUTHCLIENT_REMOTE_APPS=dict(
+            custom_app=REMOTE_APP
+        )
+    )
+    FlaskOAuth(base_app)
+    InvenioOAuthClient(base_app)
+    assert isinstance(
+        base_app.extensions['oauthlib.client'].remote_apps['custom_app'],
+        _CustomOAuthRemoteApp)
+
+
+def test_remote_app_factory_local_customization(base_app):
+    """Test custom remote_app for one app only."""
+    config_for_one_app = deepcopy(REMOTE_APP)
+    config_for_one_app['remote_app'] = _CustomOAuthRemoteApp
+    base_app.config.update(
+        OAUTHCLIENT_REMOTE_APPS=dict(
+            custom_app=config_for_one_app
+        )
+    )
+    FlaskOAuth(base_app)
+    InvenioOAuthClient(base_app)
+    assert isinstance(
+        base_app.extensions['oauthlib.client'].remote_apps['custom_app'],
+        _CustomOAuthRemoteApp)
 
 
 def test_db(request):


### PR DESCRIPTION
* NEW Enables to create custom OAuthRemoteApp instances by replacing
  the default remote application factory. (closes #45)

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>