### PR TITLE
contrib: minor CERN plugin fix

### DIFF
--- a/examples/cern_app.py
+++ b/examples/cern_app.py
@@ -149,7 +149,7 @@ principal = app.extensions['security'].principal
 def index():
     """Home page: try to print user email or redirect to login with cern."""
     if not current_user.is_authenticated:
-        return redirect(url_for("invenio_oauthclient.login",
+        return redirect(url_for('invenio_oauthclient.login',
                                 remote_app='cern'))
 
-    return "hello {}".format(current_user.email)
+    return 'hello {}'.format(current_user.email)

--- a/examples/github_app.py
+++ b/examples/github_app.py
@@ -145,13 +145,13 @@ app.register_blueprint(blueprint_userprofile_init)
 @app.route('/')
 def index():
     """Homepage."""
-    return "Home page (without any restrictions)"
+    return 'Home page (without any restrictions)'
 
 
 @app.route('/github')
 def github():
     """Try to print user email or redirect to login with github."""
     if not current_user.is_authenticated:
-        return redirect(url_for("invenio_oauthclient.login",
+        return redirect(url_for('invenio_oauthclient.login',
                                 remote_app='github'))
-    return "hello {}".format(current_user.email)
+    return 'hello {}'.format(current_user.email)

--- a/examples/orcid_app.py
+++ b/examples/orcid_app.py
@@ -144,6 +144,6 @@ app.register_blueprint(blueprint_userprofile_init)
 def index():
     """Home page: try to print user email or redirect to login with orcid."""
     if not current_user.is_authenticated:
-        return redirect(url_for("invenio_oauthclient.login",
+        return redirect(url_for('invenio_oauthclient.login',
                                 remote_app='orcid'))
-    return "hello {}".format(current_user.email)
+    return 'hello {}'.format(current_user.email)

--- a/invenio_oauthclient/config.py
+++ b/invenio_oauthclient/config.py
@@ -213,7 +213,7 @@ setting ``remote_app`` in your remote application configuration.
 OAUTHCLIENT_REMOTE_APPS = {}
 """Configuration of remote applications."""
 
-OAUTHCLIENT_SESSION_KEY_PREFIX = "oauth_token"
+OAUTHCLIENT_SESSION_KEY_PREFIX = 'oauth_token'
 """Session key prefix used when storing the access token for a remote app."""
 
 OAUTHCLIENT_STATE_EXPIRES = 300

--- a/invenio_oauthclient/contrib/cern.py
+++ b/invenio_oauthclient/contrib/cern.py
@@ -87,7 +87,7 @@ import copy
 import re
 
 from flask import current_app, session
-from flask_principal import RoleNeed, identity_loaded
+from flask_principal import UserNeed, RoleNeed, identity_loaded
 
 from invenio_oauthclient.utils import oauth_link_external_id
 from invenio_db import db
@@ -236,7 +236,9 @@ def account_setup(remote, token, resp):
         oauth_link_external_id(user, dict(id=external_id, method='cern'))
 
     groups = fetch_groups(res['Group'])
-    session['identity.cern_provides'] = [RoleNeed(group) for group in groups]
+    provides = [UserNeed(user.email)] + \
+               [RoleNeed('{0}@cern.ch'.format(group)) for group in groups]
+    session['identity.cern_provides'] = provides
 
 
 @identity_loaded.connect

--- a/invenio_oauthclient/contrib/cern.py
+++ b/invenio_oauthclient/contrib/cern.py
@@ -124,26 +124,26 @@ CFG_EXTERNAL_AUTH_HIDDEN_GROUPS_RE = (
 )
 
 REMOTE_APP = dict(
-    title="CERN",
-    description="Connecting to CERN Organization.",
-    icon="",
-    authorized_handler="invenio_oauthclient.handlers"
-                       ":authorized_signup_handler",
-    disconnect_handler="invenio_oauthclient.handlers"
-                       ":disconnect_handler",
+    title='CERN',
+    description='Connecting to CERN Organization.',
+    icon='',
+    authorized_handler='invenio_oauthclient.handlers'
+                       ':authorized_signup_handler',
+    disconnect_handler='invenio_oauthclient.handlers'
+                       ':disconnect_handler',
     signup_handler=dict(
-        info="invenio_oauthclient.contrib.cern:account_info",
-        setup="invenio_oauthclient.contrib.cern:account_setup",
-        view="invenio_oauthclient.handlers:signup_handler",
+        info='invenio_oauthclient.contrib.cern:account_info',
+        setup='invenio_oauthclient.contrib.cern:account_setup',
+        view='invenio_oauthclient.handlers:signup_handler',
     ),
     params=dict(
-        base_url="https://oauth.web.cern.ch/",
+        base_url='https://oauth.web.cern.ch/',
         request_token_url=None,
-        access_token_url="https://oauth.web.cern.ch/OAuth/Token",
-        access_token_method="POST",
-        authorize_url="https://oauth.web.cern.ch/OAuth/Authorize",
-        app_key="CERN_APP_CREDENTIALS",
-        content_type="application/json",
+        access_token_url='https://oauth.web.cern.ch/OAuth/Token',
+        access_token_method='POST',
+        authorize_url='https://oauth.web.cern.ch/OAuth/Authorize',
+        app_key='CERN_APP_CREDENTIALS',
+        content_type='application/json',
         request_token_params={'scope': 'Name Email Bio Groups',
                               'show_login': 'true'}
     )
@@ -153,14 +153,14 @@ REMOTE_APP = dict(
 REMOTE_SANDBOX_APP = copy.deepcopy(REMOTE_APP)
 """CERN Sandbox Remote Application."""
 
-REMOTE_SANDBOX_APP["params"].update(dict(
-    base_url="https://test-oauth.web.cern.ch/",
-    access_token_url="https://test-oauth.web.cern.ch/OAuth/Token",
-    authorize_url="https://test-oauth.web.cern.ch/OAuth/Authorize",
+REMOTE_SANDBOX_APP['params'].update(dict(
+    base_url='https://test-oauth.web.cern.ch/',
+    access_token_url='https://test-oauth.web.cern.ch/OAuth/Token',
+    authorize_url='https://test-oauth.web.cern.ch/OAuth/Authorize',
 ))
 
-REMOTE_APP_RESOURCE_API_URL = "https://oauthresource.web.cern.ch/api/Me"
-REMOTE_APP_RESOURCE_SCHEMA = "http://schemas.xmlsoap.org/claims/"
+REMOTE_APP_RESOURCE_API_URL = 'https://oauthresource.web.cern.ch/api/Me'
+REMOTE_APP_RESOURCE_SCHEMA = 'http://schemas.xmlsoap.org/claims/'
 
 
 def fetch_groups(groups):
@@ -233,7 +233,7 @@ def account_setup(remote, token, resp):
         external_id = res['PersonID'][0]
 
         # Create user <-> external id link.
-        oauth_link_external_id(user, dict(id=external_id, method="cern"))
+        oauth_link_external_id(user, dict(id=external_id, method='cern'))
 
     groups = fetch_groups(res['Group'])
     session['identity.cern_provides'] = [RoleNeed(group) for group in groups]

--- a/invenio_oauthclient/contrib/github.py
+++ b/invenio_oauthclient/contrib/github.py
@@ -146,13 +146,13 @@ def account_setup(remote, token, resp):
     with db.session.begin_nested():
         me = gh.me()
 
-        token.remote_account.extra_data = {"login": me.login, "id": me.id}
+        token.remote_account.extra_data = {'login': me.login, 'id': me.id}
 
         # Create user <-> external id link.
         oauth_link_external_id(
             token.remote_account.user, dict(
                 id=str(me.id),
-                method="github")
+                method='github')
         )
 
 

--- a/invenio_oauthclient/contrib/orcid.py
+++ b/invenio_oauthclient/contrib/orcid.py
@@ -94,25 +94,25 @@ REMOTE_APP = dict(
     title='ORCID',
     description='Connecting Research and Researchers.',
     icon='',
-    authorized_handler="invenio_oauthclient.handlers"
-                       ":authorized_signup_handler",
-    disconnect_handler="invenio_oauthclient.contrib.orcid"
-                       ":disconnect_handler",
+    authorized_handler='invenio_oauthclient.handlers'
+                       ':authorized_signup_handler',
+    disconnect_handler='invenio_oauthclient.contrib.orcid'
+                       ':disconnect_handler',
     signup_handler=dict(
-        info="invenio_oauthclient.contrib.orcid:account_info",
-        setup="invenio_oauthclient.contrib.orcid:account_setup",
-        view="invenio_oauthclient.handlers:signup_handler",
+        info='invenio_oauthclient.contrib.orcid:account_info',
+        setup='invenio_oauthclient.contrib.orcid:account_setup',
+        view='invenio_oauthclient.handlers:signup_handler',
     ),
     params=dict(
         request_token_params={'scope': '/authenticate',
                               'show_login': 'true'},
         base_url='https://pub.orcid.org/v1.2/',
         request_token_url=None,
-        access_token_url="https://pub.orcid.org/oauth/token",
+        access_token_url='https://pub.orcid.org/oauth/token',
         access_token_method='POST',
-        authorize_url="https://orcid.org/oauth/authorize",
-        app_key="ORCID_APP_CREDENTIALS",
-        content_type="application/json",
+        authorize_url='https://orcid.org/oauth/authorize',
+        app_key='ORCID_APP_CREDENTIALS',
+        content_type='application/json',
     )
 )
 """ ORCID Remote Application. """
@@ -121,8 +121,8 @@ REMOTE_MEMBER_APP = copy.deepcopy(REMOTE_APP)
 """ORCID Remote Application with member API."""
 
 REMOTE_MEMBER_APP['params'].update(dict(
-    base_url="https://api.orcid.org/",
-    access_token_url="https://api.orcid.org/oauth/token",
+    base_url='https://api.orcid.org/',
+    access_token_url='https://api.orcid.org/oauth/token',
 ))
 """ORCID sandbox member API."""
 
@@ -130,9 +130,9 @@ REMOTE_SANDBOX_MEMBER_APP = copy.deepcopy(REMOTE_APP)
 """ORCID Sandbox Remote Application with member API."""
 
 REMOTE_SANDBOX_MEMBER_APP['params'].update(dict(
-    base_url="https://api.sandbox.orcid.org/",
-    access_token_url="https://api.sandbox.orcid.org/oauth/token",
-    authorize_url="https://sandbox.orcid.org/oauth/authorize#show_login",
+    base_url='https://api.sandbox.orcid.org/',
+    access_token_url='https://api.sandbox.orcid.org/oauth/token',
+    authorize_url='https://sandbox.orcid.org/oauth/authorize#show_login',
 ))
 """ORCID sandbox member API."""
 
@@ -140,20 +140,20 @@ REMOTE_SANDBOX_APP = copy.deepcopy(REMOTE_APP)
 """ORCID Sandbox Remote Application with public API."""
 
 REMOTE_SANDBOX_APP['params'].update(dict(
-    base_url="https://pub.sandbox.orcid.org/",
-    access_token_url="https://pub.sandbox.orcid.org/oauth/token",
-    authorize_url="https://sandbox.orcid.org/oauth/authorize#show_login",
+    base_url='https://pub.sandbox.orcid.org/',
+    access_token_url='https://pub.sandbox.orcid.org/oauth/token',
+    authorize_url='https://sandbox.orcid.org/oauth/authorize#show_login',
 ))
 """ORCID sandbox public API."""
 
 
 def account_info(remote, resp):
     """Retrieve remote account information used to find local user."""
-    orcid = resp.get("orcid")
+    orcid = resp.get('orcid')
 
     return dict(
         external_id=orcid,
-        external_method="orcid",
+        external_method='orcid',
         user=dict()
     )
 
@@ -180,11 +180,11 @@ def account_setup(remote, token, resp):
     """Perform additional setup after user have been logged in."""
     with db.session.begin_nested():
         # Retrieve ORCID from response.
-        orcid = resp.get("orcid")
+        orcid = resp.get('orcid')
 
         # Set ORCID in extra_data.
-        token.remote_account.extra_data = {"orcid": orcid}
+        token.remote_account.extra_data = {'orcid': orcid}
         user = token.remote_account.user
 
         # Create user <-> external id link.
-        oauth_link_external_id(user, dict(id=orcid, method="orcid"))
+        oauth_link_external_id(user, dict(id=orcid, method='orcid'))

--- a/invenio_oauthclient/utils.py
+++ b/invenio_oauthclient/utils.py
@@ -49,7 +49,7 @@ def _commit(response=None):
 
 def _get_external_id(account_info):
     """Get external id from account info."""
-    if all(k in account_info for k in ("external_id", "external_method")):
+    if all(k in account_info for k in ('external_id', 'external_method')):
         return dict(id=account_info['external_id'],
                     method=account_info['external_method'])
     return None

--- a/invenio_oauthclient/version.py
+++ b/invenio_oauthclient/version.py
@@ -28,4 +28,4 @@ This file is imported by ``invenio_oauthclient.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "1.0.0a7.dev20160623"
+__version__ = '1.0.0a7.dev20160623'

--- a/invenio_oauthclient/views/client.py
+++ b/invenio_oauthclient/views/client.py
@@ -34,9 +34,9 @@ from ..utils import get_safe_redirect_target
 blueprint = Blueprint(
     'invenio_oauthclient',
     __name__,
-    url_prefix="/oauth",
-    static_folder="../static",
-    template_folder="../templates",
+    url_prefix='/oauth',
+    static_folder='../static',
+    template_folder='../templates',
 )
 
 
@@ -54,20 +54,20 @@ def post_ext_init(state):
     app = state.app
 
     app.config.setdefault(
-        "OAUTHCLIENT_SITENAME",
-        app.config.get("THEME_SITENAME", "Invenio"))
+        'OAUTHCLIENT_SITENAME',
+        app.config.get('THEME_SITENAME', 'Invenio'))
     app.config.setdefault(
-        "OAUTHCLIENT_BASE_TEMPLATE",
-        app.config.get("BASE_TEMPLATE",
-                       "invenio_oauthclient/base.html"))
+        'OAUTHCLIENT_BASE_TEMPLATE',
+        app.config.get('BASE_TEMPLATE',
+                       'invenio_oauthclient/base.html'))
     app.config.setdefault(
-        "OAUTHCLIENT_COVER_TEMPLATE",
-        app.config.get("COVER_TEMPLATE",
-                       "invenio_oauthclient/base_cover.html"))
+        'OAUTHCLIENT_COVER_TEMPLATE',
+        app.config.get('COVER_TEMPLATE',
+                       'invenio_oauthclient/base_cover.html'))
     app.config.setdefault(
-        "OAUTHCLIENT_SETTINGS_TEMPLATE",
-        app.config.get("SETTINGS_TEMPLATE",
-                       "invenio_oauthclient/settings/base.html"))
+        'OAUTHCLIENT_SETTINGS_TEMPLATE',
+        app.config.get('SETTINGS_TEMPLATE',
+                       'invenio_oauthclient/settings/base.html'))
 
 
 @blueprint.route('/login/<remote_app>/')

--- a/invenio_oauthclient/views/settings.py
+++ b/invenio_oauthclient/views/settings.py
@@ -35,20 +35,20 @@ from ..models import RemoteAccount
 blueprint = Blueprint(
     'invenio_oauthclient_settings',
     __name__,
-    url_prefix="/account/settings/linkedaccounts",
-    static_folder="../static",
-    template_folder="../templates",
+    url_prefix='/account/settings/linkedaccounts',
+    static_folder='../static',
+    template_folder='../templates',
 )
 
 
-@blueprint.route("/", methods=['GET', 'POST'])
+@blueprint.route('/', methods=['GET', 'POST'])
 @login_required
 @register_menu(
     blueprint, 'settings.oauthclient',
     _('%(icon)s Linked accounts', icon='<i class="fa fa-link fa-fw"></i>'),
     order=3,
     active_when=lambda: request.endpoint.startswith(
-        "invenio_oauthclient_settings.")
+        'invenio_oauthclient_settings.')
 )
 @register_breadcrumb(
     blueprint, 'breadcrumbs.settings.oauthclient', _('Linked accounts')
@@ -87,6 +87,6 @@ def index():
     services.sort(key=itemgetter('title'))
 
     return render_template(
-        "invenio_oauthclient/settings/index.html",
+        'invenio_oauthclient/settings/index.html',
         services=services
     )


### PR DESCRIPTION
 * Fixes an issue where `g.identity.provides` was populated with only the
 	 Cern groups. As access rights can be assigned to single users(i.e. emails),
 	 the user's e-mail must also be included in the `g.identity.provides`.