### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-OAuthClient.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-oauthclient
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/invenio_oauthclient/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_oauthclient/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-oauthclient 0.1.1.dev20150804\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2016-02-01 09:14+0100\n"
 "PO-Revision-Date: 2015-09-01 14:58+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_oauthclient/translations/es/LC_MESSAGES/messages.po
+++ b/invenio_oauthclient/translations/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-oauthclient 0.1.1.dev20150804\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2016-02-01 09:14+0100\n"
 "PO-Revision-Date: 2015-09-01 14:57+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_oauthclient/translations/fr/LC_MESSAGES/messages.po
+++ b/invenio_oauthclient/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-oauthclient 0.1.1.dev20150804\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2016-02-01 09:14+0100\n"
 "PO-Revision-Date: 2015-09-01 14:57+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_oauthclient/translations/invenio.pot
+++ b/invenio_oauthclient/translations/invenio.pot
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-oauthclient 1.0.0a1\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2016-02-01 09:14+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_oauthclient/translations/it/LC_MESSAGES/messages.po
+++ b/invenio_oauthclient/translations/it/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-oauthclient 0.1.1.dev20150804\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2016-02-01 09:14+0100\n"
 "PO-Revision-Date: 2015-09-01 14:57+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ directory = invenio_oauthclient/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_oauthclient/translations/invenio.pot
 

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
     keywords='invenio oauth authentication',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-oauthclient',
     packages=packages,
     zip_safe=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,17 +146,17 @@ def models_fixture(app):
     with app.app_context():
         datastore = app.extensions['security'].datastore
         datastore.create_user(
-            email="existing@invenio-software.org",
+            email="existing@inveniosoftware.org",
             password='tester',
             active=True
         )
         datastore.create_user(
-            email="test2@invenio-software.org",
+            email="test2@inveniosoftware.org",
             password='tester',
             active=True
         )
         datastore.create_user(
-            email="test3@invenio-software.org",
+            email="test3@inveniosoftware.org",
             password='tester',
             active=True
         )
@@ -187,17 +187,17 @@ def views_fixture(base_app, params):
     with base_app.app_context():
         datastore = base_app.extensions['security'].datastore
         datastore.create_user(
-            email="existing@invenio-software.org",
+            email="existing@inveniosoftware.org",
             password='tester',
             active=True
         )
         datastore.create_user(
-            email="test2@invenio-software.org",
+            email="test2@inveniosoftware.org",
             password='tester',
             active=True
         )
         datastore.create_user(
-            email="test3@invenio-software.org",
+            email="test3@inveniosoftware.org",
             password='tester',
             active=True
         )
@@ -328,7 +328,7 @@ def user(userprofiles_app):
     """Create users."""
     with db.session.begin_nested():
         datastore = userprofiles_app.extensions['security'].datastore
-        user1 = datastore.create_user(email='info@invenio-software.org',
+        user1 = datastore.create_user(email='info@inveniosoftware.org',
                                       password='tester', active=True)
         profile = UserProfile(username='mynick', user=user1)
         db.session.add(profile)

--- a/tests/test_contrib_cern.py
+++ b/tests/test_contrib_cern.py
@@ -91,7 +91,7 @@ def test_account_setup(app, example_cern, models_fixture):
 
     app = models_fixture
     datastore = app.extensions['invenio-accounts'].datastore
-    user = datastore.find_user(email="existing@invenio-software.org")
+    user = datastore.find_user(email="existing@inveniosoftware.org")
     token = RemoteToken.create(
         user.id, 'client_id', example_token['access_token'], 'secret',
         token_type=example_token['token_type']

--- a/tests/test_contrib_github.py
+++ b/tests/test_contrib_github.py
@@ -80,12 +80,12 @@ class MockGh(object):
 
 def test_authorized_signup_valid_user(app, example_github):
     """Test authorized callback with sign-up."""
-    example_email = "info@invenio-software.org"
+    example_email = "info@inveniosoftware.org"
 
     with app.test_client() as c:
         # User login with email 'info'
         with mock.patch('github3.login') as MockLogin:
-            MockLogin.return_value = MockGh(email='info@invenio-software.org')
+            MockLogin.return_value = MockGh(email='info@inveniosoftware.org')
 
             # Ensure remote apps have been loaded (due to before first
             # request)
@@ -128,7 +128,7 @@ def test_authorized_signup_valid_user(app, example_github):
 
         # User login with another email ('info2')
         with mock.patch('github3.login') as MockLogin:
-            MockLogin.return_value = MockGh(email='info2@invenio-software.org')
+            MockLogin.return_value = MockGh(email='info2@inveniosoftware.org')
 
             # User authorized the requests and is redirect back
             resp = c.get(
@@ -235,7 +235,7 @@ def test_authorized_already_authenticated(models_fixture, example_github):
     datastore = app.extensions['invenio-accounts'].datastore
     login_manager = app.login_manager
 
-    existing_email = "existing@invenio-software.org"
+    existing_email = "existing@inveniosoftware.org"
     user = datastore.find_user(email=existing_email)
 
     @login_manager.user_loader
@@ -248,7 +248,7 @@ def test_authorized_already_authenticated(models_fixture, example_github):
         return "Logged In"
 
     with mock.patch('github3.login') as MockLogin:
-        MockLogin.return_value = MockGh(email='info@invenio-software.org')
+        MockLogin.return_value = MockGh(email='info@inveniosoftware.org')
 
         with app.test_client() as client:
 

--- a/tests/test_contrib_orcid.py
+++ b/tests/test_contrib_orcid.py
@@ -75,7 +75,7 @@ def test_authorized_signup(userprofiles_app, example_orcid, orcid_bio):
     """Test authorized callback with sign-up."""
     app = userprofiles_app
     example_data, example_account_info = example_orcid
-    example_email = "orcidtest@invenio-software.org"
+    example_email = "orcidtest@inveniosoftware.org"
 
     with app.test_client() as c:
         # Ensure remote apps have been loaded (due to before first
@@ -177,7 +177,7 @@ def test_authorized_already_authenticated(models_fixture, example_orcid,
     login_manager = app.login_manager
 
     example_data, example_account_info = example_orcid
-    existing_email = "existing@invenio-software.org"
+    existing_email = "existing@inveniosoftware.org"
     user = datastore.find_user(email=existing_email)
 
     @login_manager.user_loader

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -43,7 +43,7 @@ def test_get_create_remote_account(models_fixture):
 def test_get_create_remote_token(models_fixture):
     """Test create remote token."""
     app = models_fixture
-    existing_email = "existing@invenio-software.org"
+    existing_email = "existing@inveniosoftware.org"
     datastore = app.extensions['invenio-accounts'].datastore
     user = datastore.find_user(email=existing_email)
 
@@ -77,8 +77,8 @@ def test_get_regression(models_fixture):
     app = models_fixture
     datastore = app.extensions['invenio-accounts'].datastore
 
-    email2 = "test2@invenio-software.org"
-    email3 = "test3@invenio-software.org"
+    email2 = "test2@inveniosoftware.org"
+    email3 = "test3@inveniosoftware.org"
 
     user2 = datastore.find_user(email=email2)
     user3 = datastore.find_user(email=email3)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -60,7 +60,7 @@ def test_redirect_uri(views_fixture):
         # Test redirect
         resp = client.get(
             url_for("invenio_oauthclient.login", remote_app='test',
-                    next='http://invenio-software.org')
+                    next='http://inveniosoftware.org')
         )
         assert resp.status_code == 302
 
@@ -450,13 +450,13 @@ def test_settings_view(views_fixture):
 
     @app.route('/foo_login')
     def login():
-        user = datastore.find_user(email="existing@invenio-software.org")
+        user = datastore.find_user(email="existing@inveniosoftware.org")
         login_user(user)
         return "Logged In"
 
     with app.app_context():
         with app.test_client() as client:
-            user = datastore.find_user(email="existing@invenio-software.org")
+            user = datastore.find_user(email="existing@inveniosoftware.org")
             RemoteAccount.create(user.get_id(), 'testid', None)
 
             resp = client.get(url_for('invenio_oauthclient_settings.index'),


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>