### PR TITLE
contrib: CERN typo fix

### DIFF
--- a/invenio_oauthclient/contrib/cern.py
+++ b/invenio_oauthclient/contrib/cern.py
@@ -171,7 +171,7 @@ def fetch_groups(groups):
         'OAUTHCLIENT_CERN_HIDDEN_GROUPS', OAUTHCLIENT_CERN_HIDDEN_GROUPS)
     hidden_groups_re = current_app.config.get(
         'OAUTHCLIENT_CERN_HIDDEN_GROUPS_RE',
-        OAUTHCLIENT_CERN_HIDDEN_GROUPS)
+        OAUTHCLIENT_CERN_HIDDEN_GROUPS_RE)
     groups = [group for group in groups if group not in hidden_groups]
     filter_groups = []
     for regexp in hidden_groups_re:

--- a/setup.py
+++ b/setup.py
@@ -58,13 +58,13 @@ extras_require = {
     ],
     'orcid': [],
     'mysql': [
-        'invenio-db[mysql]>=1.0.0a9',
+        'invenio-db[mysql]>=1.0.0b1',
     ],
     'postgresql': [
-        'invenio-db[postgresql]>=1.0.0a9',
+        'invenio-db[postgresql]>=1.0.0b1',
     ],
     'sqlite': [
-        'invenio-db>=1.0.0a9',
+        'invenio-db>=1.0.0b1',
     ],
     'tests': tests_require,
 }
@@ -86,7 +86,7 @@ install_requires = [
     'Flask-CLI>=0.2.1',
     'Flask-OAuthlib>=0.9.3',
     'Flask-Security>=1.7.5',
-    'Flask>=0.10.1',
+    'Flask>=0.11.1',
     'blinker>=1.4',
     'cryptography>=0.6',  # sqlalchemy-utils dependency
     'invenio-accounts>=1.0.0a8',

--- a/tests/test_contrib_cern.py
+++ b/tests/test_contrib_cern.py
@@ -40,7 +40,7 @@ def test_fetch_groups(app, example_cern):
     # Override hidden group configuration
     import re
     cern.OAUTHCLIENT_CERN_HIDDEN_GROUPS = ('hidden_group',)
-    cern.OAUTHCLIENT_CERN_HIDDEN_GROUPS = (re.compile(r'Group[1-3]'),)
+    cern.OAUTHCLIENT_CERN_HIDDEN_GROUPS_RE = (re.compile(r'Group[1-3]'),)
 
     # Check that groups were hidden as required
     groups = fetch_groups(res['Group'])


### PR DESCRIPTION
* Fixes a small typo in the `fetch_groups` method, which incorrectly retrieves
  the `CERN_HIDDEN_GROUPS` instead of `CERN_HIDDEN_GROUPS_RE`.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>