### PR TITLE
global: ext warning fix

### DIFF
--- a/invenio_oauthclient/admin.py
+++ b/invenio_oauthclient/admin.py
@@ -21,7 +21,7 @@
 
 from __future__ import absolute_import, print_function
 
-from flask.ext.admin.contrib.sqla import ModelView
+from flask_admin.contrib.sqla import ModelView
 
 from .models import RemoteAccount, RemoteToken
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ tests_require = [
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
     'simplejson>=3.8',
-    'invenio-userprofiles>=1.0.0a6',
+    'invenio-accounts>=1.0.0a15',
+    'invenio-userprofiles>=1.0.0a8',
 ]
 
 extras_require = {
@@ -82,7 +83,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'Flask-BabelEx>=0.9.2',
+    'Flask-BabelEx>=0.9.3',
     'Flask-Breadcrumbs>=0.3.0',
     'Flask-OAuthlib>=0.9.3',
     'Flask-Security>=1.7.5',


### PR DESCRIPTION
Fixes these warnings I just spotted on INSPIRE:
```
/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.admin is deprecated, use flask_admin instead.
  .format(x=modname), ExtDeprecationWarning

/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.admin.contrib is deprecated, use flask_admin.contrib instead.
  .format(x=modname), ExtDeprecationWarning

/Users/jacquerie/.virtualenvs/inspire/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.admin.contrib.sqla is deprecated, use flask_admin.contrib.sqla instead.
  .format(x=modname), ExtDeprecationWarning
```

Not sure on `global:`, because it's a very local thing...