### PR TITLE
Release v1.0.0a13

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,6 @@
 ..
     This file is part of Invenio.
-    Copyright (C) 2015, 2016 CERN.
+    Copyright (C) 2015, 2016, 2017 CERN.
 
     Invenio is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
@@ -24,7 +24,7 @@
 Changes
 =======
 
-Version 1.0.0a12 (released 2016-11-11)
+Version 1.0.0a13 (released 2017-05-05)
 --------------------------------------
 
 - Refactoring for Invenio 3.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ==============================
- Invenio-OAuthClient v1.0.0a12
+ Invenio-OAuthClient v1.0.0a13
 ==============================
 
-Invenio-OAuthClient v1.0.0a12 was released on November 11, 2016.
+Invenio-OAuthClient v1.0.0a13 was released on May 05, 2017.
 
 About
 -----
@@ -19,7 +19,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-oauthclient==1.0.0a12
+   $ pip install invenio-oauthclient==1.0.0a13
 
 Documentation
 -------------

--- a/invenio_oauthclient/version.py
+++ b/invenio_oauthclient/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -28,4 +28,4 @@ This file is imported by ``invenio_oauthclient.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '1.0.0a13.dev20161115'
+__version__ = '1.0.0a13'

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,7 +22,6 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
--e git+git://github.com/inveniosoftware/flask-security-fork.git#egg=flask-security-fork
 -e git+git://github.com/inveniosoftware/invenio-accounts.git#egg=invenio-accounts
 -e git+git://github.com/inveniosoftware/invenio-db.git#egg=invenio-db
 -e git+git://github.com/inveniosoftware/invenio-mail.git#egg=invenio-mail

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,6 @@ output-dir = invenio_oauthclient/translations/
 [update_catalog]
 input-file = invenio_oauthclient/translations/messages.pot
 output-dir = invenio_oauthclient/translations/
+
+[pydocstyle]
+add_ignore = D401


### PR DESCRIPTION
This release is needed in order to release invenio-db without breaking invenio-app-ils (see 3a679aef2928bcf919663a6bb492b9a4f0480f30 and 5398bc17376a971527f4f65a47876d5e3965197b).

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>