### PR TITLE
utils: pass remember parameter to login_user

### DIFF
--- a/invenio_oauthclient/utils.py
+++ b/invenio_oauthclient/utils.py
@@ -99,7 +99,7 @@ def oauth_authenticate(client_id, user, require_existing_link=False,
     # Authenticate via the access token (access token used to get user_id)
     if not requires_confirmation(user):
         after_this_request(_commit)
-        if login_user(user):
+        if login_user(user, remember=remember):
             if require_existing_link:
                 account = RemoteAccount.get(user.id, client_id)
                 if account is None:


### PR DESCRIPTION
* Allows oauth applications to set the remember parameter to
  avoid session to expire. (closes #133)

Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>