### PR TITLE
docs: fix readthedocs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 -e .[docs,tests]
+invenio-db>=1.0.0b7


### PR DESCRIPTION
* Fixes readthedocs.org documentation build. (addresses #146)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>