### PR TITLE
handlers: fill csrf token on auto signup form

### DIFF
--- a/invenio_oauthclient/handlers.py
+++ b/invenio_oauthclient/handlers.py
@@ -42,8 +42,9 @@ from .models import RemoteAccount, RemoteToken
 from .proxies import current_oauthclient
 from .signals import account_info_received, account_setup_committed, \
     account_setup_received
-from .utils import disable_csrf, fill_form, oauth_authenticate, \
-    oauth_get_user, oauth_register, registrationform_cls
+from .utils import create_csrf_disabled_registrationform, \
+    create_registrationform, fill_form, oauth_authenticate, oauth_get_user, \
+    oauth_register
 
 
 #
@@ -305,9 +306,9 @@ def authorized_signup_handler(resp, remote, *args, **kwargs):
 
         if user is None:
             # Auto sign-up if user not found
-            form_cls = registrationform_cls()
+            form = create_csrf_disabled_registrationform()
             form = fill_form(
-                disable_csrf(form_cls()),
+                form,
                 account_info['user']
             )
             user = oauth_register(form)
@@ -403,7 +404,7 @@ def signup_handler(remote, *args, **kwargs):
     if not session.get(session_prefix + '_autoregister', False):
         return redirect(url_for('.login', remote_app=remote.name))
 
-    form = registrationform_cls()(request.form)
+    form = create_registrationform(request.form)
 
     if form.validate_on_submit():
         account_info = session.get(session_prefix + '_account_info')

--- a/invenio_oauthclient/utils.py
+++ b/invenio_oauthclient/utils.py
@@ -200,12 +200,12 @@ def load_or_import_from_config(key, app=None, default=None):
     return obj_or_import_string(imp, default=default)
 
 
-def registrationform_cls():
+def create_registrationform(*args, **kwargs):
     """Make a registration form."""
     class RegistrationForm(_security.confirm_register_form):
         password = None
         recaptcha = None
-    return RegistrationForm
+    return RegistrationForm(*args, **kwargs)
 
 
 def fill_form(form, data):
@@ -224,12 +224,14 @@ def fill_form(form, data):
     return form
 
 
-def disable_csrf(form):
-    """Disable CSRF protection."""
-    form.csrf_enabled = False
-    for f in form:
-        if isinstance(f, FormField):
-            disable_csrf(f.form)
+def create_csrf_disabled_registrationform():
+    """Create a registration form with CSRF disabled."""
+    import flask_wtf
+    from pkg_resources import parse_version
+    if parse_version(flask_wtf.__version__) >= parse_version("0.14.0"):
+        form = create_registrationform(meta={'csrf': False})
+    else:
+        form = create_registrationform(csrf_enabled=False)
     return form
 
 


### PR DESCRIPTION
* Auto fill csrf_token to avoid csrf validation error on self
  submission. csrf_token validation flag differs from Flask-WTF
  version 0.13 to 0.14. Moreover, the old flag will be removed on
  Flask-WTF 1. (closes #115)

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>