### PR TITLE
utils: Change redirect uri check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@
 Changes
 =======
 
-Version 1.0.0b3 (released 2017-10-27)
+Version 1.0.0b4 (released 2018-01-22)
 -------------------------------------
 
 - Initial public release

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ==============================
- Invenio-OAuthClient v1.0.0b3
+ Invenio-OAuthClient v1.0.0b4
 ==============================
 
-Invenio-OAuthClient v1.0.0b3 was released on October 27, 2017.
+Invenio-OAuthClient v1.0.0b4 was released on January 22, 2018.
 
 About
 -----
@@ -17,7 +17,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-oauthclient==1.0.0b3
+   $ pip install invenio-oauthclient==1.0.0b4
 
 Documentation
 -------------

--- a/invenio_oauthclient/version.py
+++ b/invenio_oauthclient/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.0b3'
+__version__ = '1.0.0b4'

--- a/setup.py
+++ b/setup.py
@@ -89,8 +89,7 @@ install_requires = [
     'Flask-OAuthlib>=0.9.3',
     'Flask>=0.11.1',
     'blinker>=1.4',
-    # fix issue with cryptography old version and cffi new version
-    'cryptography>=1.5',  # sqlalchemy-utils dependency
+    'invenio-accounts>=1.0.0b12',
     'invenio-accounts>=1.0.0b7',
     'invenio-mail>=1.0.0b1',
     'six>=1.9',

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -28,6 +28,7 @@ from inspect import isfunction
 
 import six
 from mock import MagicMock
+from six.moves.urllib_parse import parse_qs, urlparse
 
 from invenio_oauthclient._compat import _create_identifier
 from invenio_oauthclient.views.client import serializer
@@ -60,3 +61,11 @@ def check_redirect_location(resp, loc):
         assert resp.headers['Location'] == loc
     elif isfunction(loc):
         assert loc(resp.headers['Location'])
+
+
+def check_response_redirect_url(response, expected_url):
+    """Check response redirect url."""
+    assert response.status_code == 302
+    state = serializer.loads(
+        parse_qs(urlparse(response.location).query)['state'][0])
+    assert expected_url == state['next']


### PR DESCRIPTION
Returns always relative paths except if the `APP_ALLOWED_HOSTS`
variable is set, thus checks the host to be included in that list.