### PR TITLE
import EncryptedType correctly from sqlalchemy_utils

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,15 +24,10 @@
 Changes
 =======
 
-Version 1.0.0b4 (released 2018-01-22)
+Version 1.0.0b5 (released 2018-02-21)
 -------------------------------------
 
 - Initial public release
-
-Version 1.0.0a13 (released 2017-05-05)
---------------------------------------
-
-- Refactoring for Invenio 3.
 
 Version 0.1.1 (released 2015-08-25)
 -----------------------------------

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ==============================
- Invenio-OAuthClient v1.0.0b4
+ Invenio-OAuthClient v1.0.0b5
 ==============================
 
-Invenio-OAuthClient v1.0.0b4 was released on January 22, 2018.
+Invenio-OAuthClient v1.0.0b5 was released on February 21, 2018.
 
 About
 -----
@@ -17,7 +17,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-oauthclient==1.0.0b4
+   $ pip install invenio-oauthclient==1.0.0b5
 
 Documentation
 -------------

--- a/invenio_oauthclient/alembic/97bbc733896c_create_oauthclient_tables.py
+++ b/invenio_oauthclient/alembic/97bbc733896c_create_oauthclient_tables.py
@@ -45,7 +45,7 @@ def upgrade():
         sa.Column('client_id', sa.String(length=255), nullable=False),
         sa.Column(
             'extra_data',
-            sqlalchemy_utils.types.json.JSONType(),
+            sqlalchemy_utils.JSONType(),
             nullable=False),
         sa.ForeignKeyConstraint(['user_id'], [u'accounts_user.id'], ),
         sa.PrimaryKeyConstraint('id'),
@@ -69,7 +69,7 @@ def upgrade():
         sa.Column('token_type', sa.String(length=40), nullable=False),
         sa.Column(
             'access_token',
-            sqlalchemy_utils.types.encrypted.EncryptedType(),
+            sqlalchemy_utils.EncryptedType(),
             nullable=False),
         sa.Column('secret', sa.Text(), nullable=False),
         sa.ForeignKeyConstraint(

--- a/invenio_oauthclient/models.py
+++ b/invenio_oauthclient/models.py
@@ -29,8 +29,7 @@ from invenio_accounts.models import User
 from invenio_db import db
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import backref
-from sqlalchemy_utils import JSONType
-from sqlalchemy_utils.types.encrypted import EncryptedType
+from sqlalchemy_utils import EncryptedType, JSONType
 
 
 def _secret_key():

--- a/invenio_oauthclient/version.py
+++ b/invenio_oauthclient/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.0b4'
+__version__ = '1.0.0b5'


### PR DESCRIPTION
sqlalchemy_utils recently [updated their `encrypted_type` module](https://github.com/kvesteri/sqlalchemy-utils/commit/7009afe4c8bb9bc14df5ffd205ba4aeaffbe2b75). `EncryptedType` now needs to be imported from `sqlalchemy_utils.types.encrypted.encrypted_type`.

Signed-off-by: Dinika Saxena <dinika.saxena@cern.ch>