### PR TITLE
handlers: export rest handlers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.3.1 (released 2020-06-03)
+
+- Exports rest handlers.
+
 Version 1.3.0 (released 2020-05-15)
 
 - Introduce `InvenioOAuthClientREST` extension.

--- a/invenio_oauthclient/handlers/__init__.py
+++ b/invenio_oauthclient/handlers/__init__.py
@@ -10,6 +10,11 @@
 
 from __future__ import absolute_import, print_function
 
+from .rest import authorized_default_handler as \
+    authorized_default_handler_rest, \
+    authorized_signup_handler as authorized_signup_handler_rest, \
+    disconnect_handler as disconnect_handler_rest, \
+    signup_handler as signup_handler_rest
 from .ui import authorized_default_handler, authorized_signup_handler, \
     disconnect_handler, oauth2_handle_error, \
     oauth_resp_remote_error_handler as oauth_error_handler, signup_handler
@@ -19,9 +24,12 @@ from .utils import authorized_handler, get_session_next_url, make_handler, \
     token_delete, token_getter, token_session_key, token_setter
 
 __all__ = (
+    'authorized_default_handler_rest',
     'authorized_default_handler',
     'authorized_handler',
+    'authorized_signup_handler_rest',
     'authorized_signup_handler',
+    'disconnect_handler_rest',
     'disconnect_handler',
     'get_session_next_url',
     'make_handler',
@@ -33,6 +41,7 @@ __all__ = (
     'oauth2_token_setter',
     'response_token_setter',
     'set_session_next_url',
+    'signup_handler_rest',
     'signup_handler',
     'token_delete',
     'token_getter',

--- a/invenio_oauthclient/version.py
+++ b/invenio_oauthclient/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/188

- Ideal would be to rename ui exports (import as ....) but that would break compatibility with 1.3.0 release
- How could a test for this be made? Sadly it fails only at run time but without a IdP this cannot be checked...

Import works:
![Screenshot 2020-06-03 at 13 33 31](https://user-images.githubusercontent.com/6756943/83632792-2c9c1b80-a5a0-11ea-9979-35ff7a0752b2.png)

**RDM needs this released**
