### PR TITLE
tests: dispose engine to avoid leaving open connections in mysql

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,7 @@ def base_app(request):
             if str(db.engine.url) != 'sqlite://':
                 drop_database(str(db.engine.url))
             shutil.rmtree(instance_path)
+            db.engine.dispose()
 
     request.addfinalizer(teardown)
 


### PR DESCRIPTION
This PR fixes the build in master. Closes #237 

The issue was that the session was being closed but the engine not disposed. And as explained [here](https://github.com/sqlalchemy/sqlalchemy/issues/5517) that mainly works as a "reset" so it was leaving connections open. In addition, the `drop_database` function was adding one more connection. Since the `base_app` fixture is `function` scoped, the amount of connections were piling up to a big amount (more than 200 in some cases, about 2 per test of the test suite).

Now they are left to 5 (along the whole test suite). Since I was connected to the mysql db too (to be able to query) the number of connections might be lower (e.g. 4) although there might be other services occupying connections (e.g. monitoring). In any case, connections are being closed/disposed correctly now.

```
mysql> SHOW STATUS LIKE 'max_used_connections';
+----------------------+-------+
| Variable_name        | Value |
+----------------------+-------+
| Max_used_connections | 5     |
+----------------------+-------+
```

Kudos to @max-moser for also investigating the issue!