### PR TITLE
login: add possibility to auto-redirect to external auth services

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,3 +35,4 @@ Contributors
 - Sami Hiltunen
 - Tibor Simko
 - Zacharias Zacharodimos
+- Maximilian Moser

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ MIT License
 
 Copyright (C) 2015-2018 CERN.
 Copyright (C) 2018 University of Chicago.
+Copyright (C) 2021 TU Wien.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/invenio_oauthclient/config.py
+++ b/invenio_oauthclient/config.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C)      2021 TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -235,6 +236,8 @@ setting ``remote_app`` in your remote application configuration.
 
 """
 
+from .views.client import auto_redirect_login
+
 OAUTHCLIENT_REMOTE_APPS = {}
 """Configuration of remote applications."""
 
@@ -258,3 +261,20 @@ OAUTHCLIENT_REST_DEFAULT_ERROR_REDIRECT_URL = '/'
 
 OAUTHCLIENT_REST_DEFAULT_RESPONSE_HANDLER = None
 """Default REST response handler."""
+
+OAUTHCLIENT_AUTO_REDIRECT_TO_EXTERNAL_LOGIN = False
+"""Redirect to the only external login service under specific conditions.
+
+If this option is enabled and there is exactly one external authentication
+service enabled (i.e. one OAuthClient remote app is configured, and local
+login is disabled), the login view function will automatically redirect to
+this external authentication service.
+"""
+
+ACCOUNTS_LOGIN_VIEW_FUNCTION = auto_redirect_login
+"""The view function to use for the login endpoint.
+
+This can be either an import string, or the view function itself.
+If set to None, the default login view function from Flask-Security will be
+left as is.
+"""

--- a/invenio_oauthclient/templates/invenio_oauthclient/login_user.html
+++ b/invenio_oauthclient/templates/invenio_oauthclient/login_user.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2018 CERN.
+  Copyright (C)      2021 TU Wien.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -15,7 +16,9 @@
     {% for name in config.OAUTHCLIENT_REMOTE_APPS.keys() %}
       {{ oauth_button(name, next=request.args.get('next')) }}
     {% endfor %}
-    <h3 align="center">&mdash; OR &mdash;</h3>
+    {%- if config.ACCOUNTS_LOCAL_LOGIN_ENABLED %}
+      <h3 align="center">&mdash; OR &mdash;</h3>
+    {%- endif %}
   {% endif %}
   {{ super () }}
 {% endblock %}

--- a/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/login_user.html
+++ b/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/login_user.html
@@ -2,6 +2,7 @@
 
   This file is part of Invenio.
   Copyright (C) 2015-2020 CERN.
+  Copyright (C)      2021 TU Wien.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -19,9 +20,11 @@
     {% endfor %}
   </div>
 
-    <div class="ui horizontal divider">
-      Or
-    </div>
+    {%- if config.ACCOUNTS_LOCAL_LOGIN_ENABLED %}
+      <div class="ui horizontal divider">
+        Or
+      </div>
+    {%- endif %}
   {% endif %}
   {{ super () }}
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -62,13 +62,14 @@ setup_requires = [
 ]
 
 install_requires = [
+    'invenio-base>=1.2.4',
+    'Flask>=1.1.4,<2.0.0',
     'Flask-Breadcrumbs>=0.5.0',
     'requests-oauthlib>=0.6.2,<1.2.0',
     'oauthlib>=1.1.2,<3.0.0',
-    'Flask-OAuthlib>=0.9.5',
+    'Flask-OAuthlib>=0.9.6',
     'blinker>=1.4',
-    'invenio-accounts>=1.3.0',
-    'invenio-base>=1.2.3',
+    'invenio-accounts>=1.4.4',
     'invenio-i18n>=1.2.0',
     'invenio-theme>=1.3.4',
     'invenio-mail>=1.0.0',

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C)      2021 TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -119,6 +120,9 @@ setup(
         ],
         'invenio_base.api_blueprints': [
             'invenio_oauthclient_rest = invenio_oauthclient.views.client:rest_blueprint',
+        ],
+        'invenio_config.module': [
+            'invenio_oauthclient = invenio_oauthclient.config',
         ],
         'invenio_db.alembic': [
             'invenio_oauthclient = invenio_oauthclient:alembic',


### PR DESCRIPTION
partially closes https://github.com/inveniosoftware/docs-invenio-rdm/issues/153
requires https://github.com/inveniosoftware/invenio-accounts/pull/368

TODO:
the provided config for `ACCOUNTS_LOGIN_VIEW_FUNCTION` should override the value from `invenio_accounts.config`, but doesn't