### PR TITLE
settings: disable unlinking of last external account

### DIFF
--- a/invenio_oauthclient/contrib/cern.py
+++ b/invenio_oauthclient/contrib/cern.py
@@ -146,6 +146,8 @@ from invenio_db import db
 
 from invenio_oauthclient.errors import OAuthCERNRejectedAccountError
 from invenio_oauthclient.handlers.rest import response_handler
+from invenio_oauthclient.handlers.utils import \
+    require_more_than_one_external_account
 from invenio_oauthclient.models import RemoteAccount
 from invenio_oauthclient.proxies import current_oauthclient
 from invenio_oauthclient.utils import oauth_link_external_id, \
@@ -444,6 +446,7 @@ def account_info_rest(remote, resp):
         )
 
 
+@require_more_than_one_external_account
 def _disconnect(remote, *args, **kwargs):
     """Handle unlinking of remote account."""
     if not current_user.is_authenticated:

--- a/invenio_oauthclient/contrib/cern_openid.py
+++ b/invenio_oauthclient/contrib/cern_openid.py
@@ -76,6 +76,8 @@ from jwt import decode
 
 from invenio_oauthclient.errors import OAuthCERNRejectedAccountError
 from invenio_oauthclient.handlers.rest import response_handler
+from invenio_oauthclient.handlers.utils import \
+    require_more_than_one_external_account
 from invenio_oauthclient.models import RemoteAccount
 from invenio_oauthclient.proxies import current_oauthclient
 from invenio_oauthclient.utils import oauth_link_external_id, \
@@ -320,6 +322,7 @@ def account_info_rest(remote, resp):
         )
 
 
+@require_more_than_one_external_account
 def _disconnect(remote, *args, **kwargs):
     """Handle unlinking of remote account."""
     if not current_user.is_authenticated:

--- a/invenio_oauthclient/contrib/github.py
+++ b/invenio_oauthclient/contrib/github.py
@@ -82,6 +82,8 @@ from invenio_oauthclient.handlers.rest import \
     authorized_signup_handler as authorized_signup_rest_handler
 from invenio_oauthclient.handlers.rest import \
     oauth_resp_remote_error_handler, response_handler
+from invenio_oauthclient.handlers.utils import \
+    require_more_than_one_external_account
 from invenio_oauthclient.models import RemoteAccount
 from invenio_oauthclient.utils import oauth_link_external_id, \
     oauth_unlink_external_id
@@ -261,6 +263,7 @@ def authorized_rest(resp, remote):
     return authorized_signup_rest_handler(resp, remote)
 
 
+@require_more_than_one_external_account
 def _disconnect(remote, *args, **kwargs):
     """Handle unlinking of remote account.
 

--- a/invenio_oauthclient/contrib/globus.py
+++ b/invenio_oauthclient/contrib/globus.py
@@ -71,6 +71,8 @@ from invenio_db import db
 from invenio_oauthclient.contrib.settings import OAuthSettingsHelper
 from invenio_oauthclient.errors import OAuthResponseError
 from invenio_oauthclient.handlers.rest import response_handler
+from invenio_oauthclient.handlers.utils import \
+    require_more_than_one_external_account
 from invenio_oauthclient.models import RemoteAccount
 from invenio_oauthclient.utils import oauth_link_external_id, \
     oauth_unlink_external_id
@@ -257,6 +259,7 @@ def account_setup(remote, token, resp):
         )
 
 
+@require_more_than_one_external_account
 def _disconnect(remote, *args, **kwargs):
     """Handle unlinking of remote account.
 

--- a/invenio_oauthclient/contrib/keycloak/handlers.py
+++ b/invenio_oauthclient/contrib/keycloak/handlers.py
@@ -37,6 +37,8 @@ from flask_login import current_user
 from invenio_db import db
 
 from invenio_oauthclient.handlers.rest import response_handler
+from invenio_oauthclient.handlers.utils import \
+    require_more_than_one_external_account
 from invenio_oauthclient.models import RemoteAccount
 from invenio_oauthclient.utils import oauth_link_external_id, \
     oauth_unlink_external_id
@@ -90,6 +92,7 @@ def setup_handler(remote, token, resp):
         oauth_link_external_id(user, external_id)
 
 
+@require_more_than_one_external_account
 def _disconnect(remote, *args, **kwargs):
     """Common logic for handling disconnection of remote accounts."""
     if not current_user.is_authenticated:

--- a/invenio_oauthclient/contrib/orcid.py
+++ b/invenio_oauthclient/contrib/orcid.py
@@ -77,6 +77,8 @@ from invenio_db import db
 
 from invenio_oauthclient.contrib.settings import OAuthSettingsHelper
 from invenio_oauthclient.handlers.rest import response_handler
+from invenio_oauthclient.handlers.utils import \
+    require_more_than_one_external_account
 from invenio_oauthclient.models import RemoteAccount
 from invenio_oauthclient.utils import oauth_link_external_id, \
     oauth_unlink_external_id
@@ -210,6 +212,7 @@ def account_info(remote, resp):
     }
 
 
+@require_more_than_one_external_account
 def _disconnect(remote, *args, **kwargs):
     """Handle unlinking of remote account.
 

--- a/invenio_oauthclient/handlers/base.py
+++ b/invenio_oauthclient/handlers/base.py
@@ -11,6 +11,7 @@
 from flask import session
 from flask_login import current_user
 from invenio_db import db
+from pkg_resources import require
 
 from ..errors import OAuthClientAlreadyAuthorized, \
     OAuthClientMustRedirectLogin, OAuthClientMustRedirectSignup, \
@@ -22,8 +23,9 @@ from ..signals import account_info_received, account_setup_committed, \
     account_setup_received
 from ..utils import create_csrf_disabled_registrationform, fill_form, \
     oauth_authenticate, oauth_get_user, oauth_register
-from .utils import get_session_next_url, response_token_setter, token_getter, \
-    token_session_key, token_setter
+from .utils import get_session_next_url, \
+    require_more_than_one_external_account, response_token_setter, \
+    token_getter, token_session_key, token_setter
 
 
 #
@@ -110,6 +112,7 @@ def base_authorized_signup_handler(resp, remote, *args, **kwargs):
         return next_url
 
 
+@require_more_than_one_external_account
 def base_disconnect_handler(remote, *args, **kwargs):
     """Handle unlinking of remote account.
 

--- a/invenio_oauthclient/templates/invenio_oauthclient/settings/index.html
+++ b/invenio_oauthclient/templates/invenio_oauthclient/settings/index.html
@@ -14,6 +14,7 @@
 {% set panel_title = _("Linked accounts") %}
 {% set panel_icon = "fa fa-link" %}
 {% set num_linked_services = services|selectattr("account")|list|length %}
+{% set can_disconnect = (num_linked_services > 1 or not only_external_login) %}
 
 {% block settings_body %}
 <div class="panel-body">
@@ -28,7 +29,7 @@
       {% block oauth_controls scoped %}
       <div class="pull-right">
           {# we'll only show the "disconnect" button if it's not the only way for the user to log in #}
-          {%- if s.account and (num_linked_services > 1 or not local_login_impossible) -%}
+          {%- if s.account and can_disconnect -%}
           <a href="{{url_for('invenio_oauthclient.disconnect', remote_app=s.appid)}}" class="btn btn-default btn-xs"><i class="fa fa-times-circle"></i> {{ _('Disconnect') }}</a>
           {%- elif not s.account -%}
           <a href="{{url_for('invenio_oauthclient.login', remote_app=s.appid)}}" class="btn btn-default btn-xs"><i class="fa fa-link"></i> {{ _('Connect') }}</a>

--- a/invenio_oauthclient/templates/invenio_oauthclient/settings/index.html
+++ b/invenio_oauthclient/templates/invenio_oauthclient/settings/index.html
@@ -13,6 +13,7 @@
 
 {% set panel_title = _("Linked accounts") %}
 {% set panel_icon = "fa fa-link" %}
+{% set num_linked_services = services|selectattr("account")|list|length %}
 
 {% block settings_body %}
 <div class="panel-body">
@@ -26,9 +27,10 @@
     <li class="list-group-item">
       {% block oauth_controls scoped %}
       <div class="pull-right">
-          {%- if s.account -%}
+          {# we'll only show the "disconnect" button if it's not the only way for the user to log in #}
+          {%- if s.account and (num_linked_services > 1 or not local_login_impossible) -%}
           <a href="{{url_for('invenio_oauthclient.disconnect', remote_app=s.appid)}}" class="btn btn-default btn-xs"><i class="fa fa-times-circle"></i> {{ _('Disconnect') }}</a>
-          {%- else -%}
+          {%- elif not s.account -%}
           <a href="{{url_for('invenio_oauthclient.login', remote_app=s.appid)}}" class="btn btn-default btn-xs"><i class="fa fa-link"></i> {{ _('Connect') }}</a>
           {%- endif -%}
       </div>

--- a/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/settings/index.html
+++ b/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/settings/index.html
@@ -13,6 +13,7 @@
 
 {% set panel_title = _("Linked accounts") %}
 {% set panel_icon = "linkify icon" %}
+{% set num_linked_services = services|selectattr("account")|list|length %}
 
 {% block settings_body %}
 <div class="ui segment">
@@ -27,9 +28,10 @@
     <div class="ui basic segment">
       {% block oauth_controls scoped %}
       <div class="right floated content">
-          {%- if s.account -%}
+          {# we'll only show the "disconnect" button if it's not the only way for the user to log in #}
+          {%- if s.account and (num_linked_services > 1 or not local_login_impossible) -%}
           <a href="{{url_for('invenio_oauthclient.disconnect', remote_app=s.appid)}}" class="ui compact button mini"><i class="close icon"></i> {{ _('Disconnect') }}</a>
-          {%- else -%}
+          {%- elif not s.account -%}
           <a href="{{url_for('invenio_oauthclient.login', remote_app=s.appid)}}" class="ui compact basic button mini"><i class="linkify icon"></i> {{ _('Connect') }}</a>
           {%- endif -%}
       </div>

--- a/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/settings/index.html
+++ b/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/settings/index.html
@@ -14,6 +14,7 @@
 {% set panel_title = _("Linked accounts") %}
 {% set panel_icon = "linkify icon" %}
 {% set num_linked_services = services|selectattr("account")|list|length %}
+{% set can_disconnect = (num_linked_services > 1 or not only_external_login) %}
 
 {% block settings_body %}
 <div class="ui segment">
@@ -29,7 +30,7 @@
       {% block oauth_controls scoped %}
       <div class="right floated content">
           {# we'll only show the "disconnect" button if it's not the only way for the user to log in #}
-          {%- if s.account and (num_linked_services > 1 or not local_login_impossible) -%}
+          {%- if s.account and can_disconnect -%}
           <a href="{{url_for('invenio_oauthclient.disconnect', remote_app=s.appid)}}" class="ui compact button mini"><i class="close icon"></i> {{ _('Disconnect') }}</a>
           {%- elif not s.account -%}
           <a href="{{url_for('invenio_oauthclient.login', remote_app=s.appid)}}" class="ui compact basic button mini"><i class="linkify icon"></i> {{ _('Connect') }}</a>

--- a/invenio_oauthclient/views/settings.py
+++ b/invenio_oauthclient/views/settings.py
@@ -89,5 +89,5 @@ def index():
     return render_template(
         'invenio_oauthclient/settings/index.html',
         services=services,
-        local_login_impossible=not local_login_possible,
+        only_external_login=not local_login_possible,
     )

--- a/invenio_oauthclient/views/settings.py
+++ b/invenio_oauthclient/views/settings.py
@@ -79,7 +79,15 @@ def index():
     # Sort according to title
     services.sort(key=itemgetter('title'))
 
+    # Check if local login is possible
+    local_login_enabled = current_app.config.get(
+        "ACCOUNTS_LOCAL_LOGIN_ENABLED", True
+    )
+    password_set = current_user.password is not None
+    local_login_possible = local_login_enabled and password_set
+
     return render_template(
         'invenio_oauthclient/settings/index.html',
-        services=services
+        services=services,
+        local_login_impossible=not local_login_possible,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,7 @@ def base_app(request):
     instance_path = tempfile.mkdtemp()
     base_app = Flask('testapp')
     base_app.config.update(
+        ACCOUNTS_LOCAL_LOGIN_ENABLED=True,
         TESTING=True,
         WTF_CSRF_ENABLED=False,
         LOGIN_DISABLED=False,

--- a/tests/test_contrib_cern.py
+++ b/tests/test_contrib_cern.py
@@ -10,6 +10,7 @@
 
 from flask import g, session, url_for
 from flask_security import login_user, logout_user
+from flask_security.utils import hash_password
 from helpers import get_state, mock_remote_get, mock_response
 from six.moves.urllib_parse import parse_qs, urlparse
 
@@ -126,6 +127,7 @@ def test_account_setup(app, example_cern, models_fixture):
 
     datastore = app.extensions['invenio-accounts'].datastore
     user = datastore.find_user(email='test.account@cern.ch')
+    user.password = hash_password("1234")
     assert user
 
     with app.test_request_context():

--- a/tests/test_contrib_cern_openid.py
+++ b/tests/test_contrib_cern_openid.py
@@ -13,6 +13,7 @@ import os
 import pytest
 from flask import g, session, url_for
 from flask_security import login_user, logout_user
+from flask_security.utils import hash_password
 from helpers import get_state, mock_remote_get, mock_response
 from six.moves.urllib_parse import parse_qs, urlparse
 
@@ -108,6 +109,7 @@ def test_account_setup(app, example_cern_openid, models_fixture):
 
     datastore = app.extensions['invenio-accounts'].datastore
     user = datastore.find_user(email='john.doe@cern.ch')
+    user.password = hash_password("1234")
     assert user
 
     with app.test_request_context():

--- a/tests/test_contrib_cern_openid_rest.py
+++ b/tests/test_contrib_cern_openid_rest.py
@@ -15,6 +15,7 @@ import pytest
 from flask import current_app, g, session, url_for
 from flask_login import current_user
 from flask_security import login_user, logout_user
+from flask_security.utils import hash_password
 from helpers import check_response_redirect_url_args, get_state, \
     mock_remote_get, mock_response
 from six.moves.urllib_parse import parse_qs, urlparse
@@ -117,6 +118,7 @@ def test_account_setup(app_rest, example_cern_openid_rest, models_fixture):
 
     datastore = app_rest.extensions['invenio-accounts'].datastore
     user = datastore.find_user(email='john.doe@cern.ch')
+    user.password = hash_password("1234")
     assert user
 
     with app_rest.test_request_context():

--- a/tests/test_contrib_cern_rest.py
+++ b/tests/test_contrib_cern_rest.py
@@ -11,6 +11,7 @@
 from flask import g, session, url_for
 from flask_principal import AnonymousIdentity, Identity, RoleNeed, UserNeed
 from flask_security import login_user, logout_user
+from flask_security.utils import hash_password
 from helpers import check_response_redirect_url_args, get_state, \
     mock_remote_get, mock_response
 from six.moves.urllib_parse import parse_qs, urlparse
@@ -120,6 +121,7 @@ def test_account_setup(app_rest, example_cern, models_fixture):
 
     datastore = app_rest.extensions['invenio-accounts'].datastore
     user = datastore.find_user(email='test.account@cern.ch')
+    user.password = hash_password("1234")
     assert user
 
     with app_rest.test_request_context():

--- a/tests/test_contrib_orcid.py
+++ b/tests/test_contrib_orcid.py
@@ -12,8 +12,10 @@ import httpretty
 from flask import session, url_for
 from flask_login import current_user
 from flask_security import login_user
+from flask_security.utils import hash_password
 from helpers import get_state, mock_response
 from invenio_accounts.models import User
+from invenio_db import db
 from six.moves.urllib_parse import parse_qs, urlparse
 
 from invenio_oauthclient.contrib.orcid import account_info
@@ -127,6 +129,23 @@ def test_authorized_signup(app_with_userprofiles, example_orcid, orcid_bio):
         #  assert hasattr(locmem, 'outbox') and len(locmem.outbox) == 1
 
         # Disconnect link
+        # should not work, because it's the user's only means of login
+        resp = c.get(
+            url_for('invenio_oauthclient.disconnect', remote_app='orcid')
+        )
+        assert resp.status_code == 400
+
+        user = User.query.filter_by(email=example_email).one()
+        assert 1 == UserIdentity.query.filter_by(
+            method='orcid', id_user=user.id,
+            id=example_data['orcid']
+        ).count()
+
+        # set a password for the user
+        user.password = hash_password("1234")
+        db.session.commit()
+
+        # Disconnect again
         resp = c.get(
             url_for('invenio_oauthclient.disconnect', remote_app='orcid'))
         assert resp.status_code == 302

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -470,8 +470,6 @@ def test_settings_view(views_fixture):
     with app.app_context():
         with app.test_client() as client:
             user = datastore.find_user(email='existing@inveniosoftware.org')
-            assert app.config["ACCOUNTS_LOCAL_LOGIN_ENABLED"]
-            assert user.password is not None
             RemoteAccount.create(user.get_id(), 'testid', None)
 
             resp = client.get(url_for('invenio_oauthclient_settings.index'),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -470,6 +470,8 @@ def test_settings_view(views_fixture):
     with app.app_context():
         with app.test_client() as client:
             user = datastore.find_user(email='existing@inveniosoftware.org')
+            assert app.config["ACCOUNTS_LOCAL_LOGIN_ENABLED"]
+            assert user.password is not None
             RemoteAccount.create(user.get_id(), 'testid', None)
 
             resp = client.get(url_for('invenio_oauthclient_settings.index'),


### PR DESCRIPTION
* this only applies if the user can't login to their local account
  (either ACCOUNTS_LOCAL_LOGIN_ENABLED=False, or they don't have a
  password set)

closes #251 