### PR TITLE
contrib: fix CERN contrib signal

### DIFF
--- a/tests/test_contrib_cern.py
+++ b/tests/test_contrib_cern.py
@@ -87,6 +87,7 @@ def test_account_info(app, example_cern):
 
     assert account_info(
         ioc.remote_apps['cern'], None) == example_account_info
+    assert g.oauth_logged_in_with_remote == ioc.remote_apps['cern']
 
     assert account_info(ioc.remote_apps['cern'], {}) == \
         dict(
@@ -134,6 +135,9 @@ def test_account_setup(app, example_cern, models_fixture):
         resp = disconnect_handler(ioc.remote_apps['cern'])
         assert resp.status_code >= 300
 
+        # simulate login (account_info fetch)
+        g.oauth_logged_in_with_remote = ioc.remote_apps['cern']
+
         login_user(user)
         assert len(g.identity.provides) == 7
 
@@ -143,6 +147,7 @@ def test_account_setup(app, example_cern, models_fixture):
         assert OAUTHCLIENT_CERN_SESSION_KEY not in session
 
         # Login again to test the disconnect handler
+        g.oauth_logged_in_with_remote = ioc.remote_apps['cern']
         login_user(user)
         assert len(g.identity.provides) == 7
 

--- a/tests/test_contrib_cern_openid.py
+++ b/tests/test_contrib_cern_openid.py
@@ -79,6 +79,7 @@ def test_account_info(app, example_cern_openid):
 
     assert account_info(
         ioc.remote_apps['cern_openid'], None) == example_account_info
+    assert g.oauth_logged_in_with_remote == ioc.remote_apps['cern_openid']
 
 
 def test_account_setup(app, example_cern_openid, models_fixture):
@@ -116,6 +117,9 @@ def test_account_setup(app, example_cern_openid, models_fixture):
         resp = disconnect_handler(ioc.remote_apps['cern_openid'])
         assert resp.status_code >= 300
 
+        # simulate login (account_info fetch)
+        g.oauth_logged_in_with_remote = ioc.remote_apps['cern_openid']
+
         login_user(user)
         assert len(g.identity.provides) == 3
 
@@ -125,6 +129,7 @@ def test_account_setup(app, example_cern_openid, models_fixture):
         assert OAUTHCLIENT_CERN_OPENID_SESSION_KEY not in session
 
         # Login again to test the disconnect handler
+        g.oauth_logged_in_with_remote = ioc.remote_apps['cern_openid']
         login_user(user)
         assert len(g.identity.provides) == 3
 

--- a/tests/test_contrib_cern_openid_rest.py
+++ b/tests/test_contrib_cern_openid_rest.py
@@ -125,6 +125,9 @@ def test_account_setup(app_rest, example_cern_openid_rest, models_fixture):
         resp = disconnect_rest_handler(ioc.remote_apps['cern_openid'])
         assert resp.status_code >= 300
 
+        # simulate login (account_info fetch)
+        g.oauth_logged_in_with_remote = ioc.remote_apps['cern_openid']
+
         login_user(user)
         assert len(g.identity.provides) == 3
 
@@ -134,6 +137,7 @@ def test_account_setup(app_rest, example_cern_openid_rest, models_fixture):
         assert OAUTHCLIENT_CERN_OPENID_SESSION_KEY not in session
 
         # Login again to test the disconnect handler
+        g.oauth_logged_in_with_remote = ioc.remote_apps['cern_openid']
         login_user(user)
         assert len(g.identity.provides) == 3
 
@@ -192,6 +196,7 @@ def test_account_info_not_allowed_account(app_rest, example_cern_openid_rest):
 
     mock_remote_get(ioc, 'cern_openid', example_response)
     resp = account_info_rest(ioc.remote_apps['cern_openid'], None)
+    assert g.oauth_logged_in_with_remote == ioc.remote_apps['cern_openid']
 
     assert resp.status_code == 302
     expected_url_args = {

--- a/tests/test_contrib_cern_rest.py
+++ b/tests/test_contrib_cern_rest.py
@@ -89,6 +89,7 @@ def test_account_info(app_rest, example_cern):
 
     assert account_info_rest(
         ioc.remote_apps['cern'], None) == example_account_info
+    assert g.oauth_logged_in_with_remote == ioc.remote_apps['cern']
 
 
 def test_account_setup(app_rest, example_cern, models_fixture):
@@ -128,6 +129,9 @@ def test_account_setup(app_rest, example_cern, models_fixture):
         resp = disconnect_rest_handler(ioc.remote_apps['cern'])
         assert resp.status_code >= 300
 
+        # simulate login (account_info fetch)
+        g.oauth_logged_in_with_remote = ioc.remote_apps['cern']
+
         login_user(user)
         assert isinstance(g.identity, Identity)
         assert g.identity.provides == set([
@@ -150,6 +154,7 @@ def test_account_setup(app_rest, example_cern, models_fixture):
         assert OAUTHCLIENT_CERN_SESSION_KEY not in session
 
         # Login again to test the disconnect handler
+        g.oauth_logged_in_with_remote = ioc.remote_apps['cern']
         login_user(user)
         assert isinstance(g.identity, Identity)
         assert len(g.identity.provides) == 7


### PR DESCRIPTION
* skip CERN contrib signals when login happened via another login method
* closes #228