### PR TITLE
handlers: fix linked account disconnection

### DIFF
--- a/invenio_oauthclient/handlers/utils.py
+++ b/invenio_oauthclient/handlers/utils.py
@@ -274,11 +274,18 @@ def require_more_than_one_external_account(f):
 
         # find out all of the linked external accounts for the user
         # that are currently configured and not hidden
+        consumer_keys = set()
+        remote_apps = current_app.config["OAUTHCLIENT_REMOTE_APPS"]
+        for name, remote_app in remote_apps.items():
+            if not remote_app.get("hide", False):
+                consumer_keys.add(name)  # backcompat with v1.5.4
+                remote_app_config = current_app.config[
+                    remote_app["params"]["app_key"]
+                ]
+                consumer_keys.add(remote_app_config["consumer_key"])
+
         linked_accounts = [
-            acc for acc in accounts
-            if acc.client_id in remote_apps and
-            not remote_apps[acc.client_id].get("hide", False)
-        ]
+            acc for acc in accounts if acc.client_id in consumer_keys]
 
         # execute the function only if local login is possible, or
         # there's more than one linked external account

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,10 @@ def base_app(request):
             consumer_key='globus_key_changeme',
             consumer_secret='globus_secret_changeme',
         ),
+        TEST_APP_CREDENTIALS=dict(
+            consumer_key='test_key_changeme',
+            consumer_secret='test_secret_changeme',
+        ),
         OAUTHCLIENT_KEYCLOAK_USER_INFO_URL=helper.user_info_url,
         OAUTHCLIENT_KEYCLOAK_REALM_URL=helper.realm_url,
         OAUTHCLIENT_KEYCLOAK_VERIFY_AUD=True,
@@ -284,6 +288,7 @@ def params():
             authorize_url='https://foo.bar/oauth/authorize',
             consumer_key=x,
             consumer_secret='testsecret',
+            app_key="TEST_APP_CREDENTIALS"
         )
 
     return params


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-oauthclient/issues/267

@slint are tests needed? I can see for example in the ORCiD tests (`test_authorized_signup`), there is a test for the 400 error done when disconnecting (and then it works). I could test the decorator but not sure we can (because of mocking) test something in a meaningful way for the views.

https://user-images.githubusercontent.com/6756943/148374499-ffb3de72-d8e8-402b-9c1e-2854f75a8ccc.mov


