### PR TITLE
templates: render 'for' attribute on checkbox label

### DIFF
--- a/invenio_oauthclient/ext.py
+++ b/invenio_oauthclient/ext.py
@@ -57,8 +57,7 @@ class _OAuthClientState(object):
         self.default_response_handler = default_response_handler or \
             dummy_handler
 
-        for remote_app, conf in app.config[
-                remote_app_config_key].items():
+        for remote_app, conf in app.config[remote_app_config_key].items():
             # Prevent double creation problems
             if remote_app not in self.oauth.remote_apps:
                 # use this app's specific remote app class if there is one.

--- a/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/_macros.html
+++ b/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/_macros.html
@@ -9,8 +9,8 @@
 
 {% macro render_checkbox(field, label='') %}
   <div class="ui checkbox">
-    {{field(class_="form-control")}}
-    <label>{{label}}</label>
+    {{ field(class_="form-control") }}
+    {{ field.label }}
   </div>
 {% endmacro %}
 


### PR DESCRIPTION
Fixing an issue we noted on our side where clicking on the label of a checkbox in our registration form didn't toggle the checkbox.