### PR TITLE
wip: groups handler

### DIFF
--- a/invenio_oauthclient/contrib/keycloak/handlers.py
+++ b/invenio_oauthclient/contrib/keycloak/handlers.py
@@ -86,6 +86,27 @@ def info_handler(remote, resp):
     return handlers["info_serializer"](resp, user_info)
 
 
+def groups_serializer_handler(remote, resp, user, groups, **kwargs):
+    """."""
+    return [{
+        "id": "my-id",
+        "name": "Group name",
+        "description": "Group description",
+    }]
+
+
+def groups_handler(remote, resp, user):
+    """."""
+    groups = [{
+        "id": "my-id",
+        "name": "Group name",
+        "description": "Group description",
+    }]
+    handlers = current_oauthclient.signup_handlers[remote.name]
+    # `remote` param automatically injected via `make_handler` helper
+    return handlers["groups_serializer"](resp, user, groups)
+
+
 def setup_handler(remote, token, resp):
     """Perform additional setup after the user has been logged in."""
     user_info = get_user_info(remote, resp)

--- a/invenio_oauthclient/ext.py
+++ b/invenio_oauthclient/ext.py
@@ -112,6 +112,14 @@ class _OAuthClientState(object):
                 remote,
                 with_response=False,
             )
+            account_groups_handler = handlers.make_handler(
+                signup_handler.get("groups", dummy_handler), remote, with_response=False
+            )
+            account_groups_serializer_handler = handlers.make_handler(
+                signup_handler.get("groups_serializer", dummy_handler),
+                remote,
+                with_response=False,
+            )
             account_setup_handler = handlers.make_handler(
                 signup_handler.get("setup", dummy_handler), remote, with_response=False
             )
@@ -122,6 +130,8 @@ class _OAuthClientState(object):
             self.signup_handlers[remote_app] = dict(
                 info=account_info_handler,
                 info_serializer=account_info_serializer_handler,
+                groups=account_groups_handler,
+                groups_serializer=account_groups_serializer_handler,
                 setup=account_setup_handler,
                 view=account_view_handler,
             )


### PR DESCRIPTION
* adds a `groups` handler to fetch groups/remote from the remote auth provider, similar to what done with user info
* TODO: update the `roles` table when groups fetched, setting the unique `id` of the role and the `is_managed` field. The roles in the DB managed by the external auth should be in sync with the ones fetched for the logged in user.
* requires: https://github.com/inveniosoftware/invenio-accounts/pull/432