### PR TITLE
contrib: fix CERN contrib login with token

### DIFF
--- a/invenio_oauthclient/alembic/bff1f190b9bd_add_timestamp_oauthclient.py
+++ b/invenio_oauthclient/alembic/bff1f190b9bd_add_timestamp_oauthclient.py
@@ -49,7 +49,6 @@ def downgrade():
 
 
 def _add_created_updated_columns(table, date):
-
     params = {"date": date}
 
     op.add_column(table, sa.Column("created", sa.DateTime()))

--- a/invenio_oauthclient/contrib/globus.py
+++ b/invenio_oauthclient/contrib/globus.py
@@ -270,7 +270,6 @@ def account_setup(remote, token, resp):
     info = get_user_info(remote)
     user_id = get_user_id(remote, info["preferred_username"])
     with db.session.begin_nested():
-
         token.remote_account.extra_data = {"login": info["username"], "id": user_id}
 
         # Create user <-> external id link.

--- a/invenio_oauthclient/utils.py
+++ b/invenio_oauthclient/utils.py
@@ -295,7 +295,7 @@ def fill_form(form, data):
     :param data: The data to insert in the form.
     :returns: A pre-filled form.
     """
-    for (key, value) in data.items():
+    for key, value in data.items():
         if hasattr(form, key):
             field = getattr(form, key)
             if isinstance(value, dict):

--- a/tests/test_contrib_cern_openid_rest.py
+++ b/tests/test_contrib_cern_openid_rest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2023 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -281,6 +281,12 @@ def test_identity_changed(app_rest, example_cern_openid_rest, models_fixture):
 
             assert current_user.login_via_oauth2
 
+            # 3 needs:
+            # {
+            #   Need(method='id', value=4),
+            #   Need(method='role', value='cern_user'),
+            #   Need(method='id', value='john.doe@cern.ch')
+            # }
             assert len(g.identity.provides) == 3
             logout_user()
 
@@ -290,7 +296,11 @@ def test_identity_changed(app_rest, example_cern_openid_rest, models_fixture):
             # login the user again
             login_user(user)
 
-            # check that the roles are not refreshed from provider
+            # 2 needs:
+            # {
+            #   Need(method='id', value=4),
+            #   Need(method='role', value='cern_user'),
+            # }
             assert len(g.identity.provides) == 2
             logout_user()
 

--- a/tests/test_contrib_github.py
+++ b/tests/test_contrib_github.py
@@ -285,7 +285,6 @@ def test_authorized_already_authenticated(app, models_fixture, example_github):
         MockLogin.return_value = MockGh(email="info@inveniosoftware.org")
 
         with app.test_client() as client:
-
             # make a fake login (using my login function)
             client.get("/foo_login", follow_redirects=True)
 

--- a/tests/test_contrib_github_rest.py
+++ b/tests/test_contrib_github_rest.py
@@ -313,7 +313,6 @@ def test_authorized_already_authenticated(app_rest, models_fixture, example_gith
         MockLogin.return_value = MockGh(email="info@inveniosoftware.org")
 
         with app_rest.test_client() as client:
-
             # make a fake login (using my login function)
             client.get("/foo_login", follow_redirects=True)
 

--- a/tests/test_contrib_globus.py
+++ b/tests/test_contrib_globus.py
@@ -180,7 +180,6 @@ def test_authorized_already_authenticated(app, models_fixture, example_globus):
         return "Logged In"
 
     with app.test_client() as client:
-
         # make a fake login (using my login function)
         client.get("/foo_login", follow_redirects=True)
         # Ensure remote apps have been loaded (due to before first request)
@@ -277,7 +276,6 @@ def test_bad_provider_response(app, example_globus):
 
 def test_invalid_user_id_response(app, example_globus):
     with app.test_client() as c:
-
         # User login with email 'info'
         ioc = app.extensions["oauthlib.client"]
 

--- a/tests/test_contrib_orcid.py
+++ b/tests/test_contrib_orcid.py
@@ -206,7 +206,6 @@ def test_authorized_already_authenticated(
         return "Logged In"
 
     with app.test_client() as client:
-
         # make a fake login (using my login function)
         client.get("/foo_login", follow_redirects=True)
 

--- a/tests/test_contrib_orcid_rest.py
+++ b/tests/test_contrib_orcid_rest.py
@@ -208,7 +208,6 @@ def test_authorized_already_authenticated(
         return "Logged In"
 
     with app_rest.test_client() as client:
-
         # make a fake login (using my login function)
         client.get("/foo_login", follow_redirects=True)
 


### PR DESCRIPTION
* fetch extra roles, cached in the DB, when the user login using a personal access token.
* closes #291