### PR TITLE
keycloak: optional realm and url modification in `KeycloakSettingsHelper`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,6 +14,7 @@ Contributors
 - Diego Rodriguez
 - Dinika Saxena
 - Dinos Kousidis
+- Domenic Gosein
 - Harri Hirvonsalo
 - Harris Tzovanakis
 - Ioannis Tsanaktsidis

--- a/invenio_oauthclient/contrib/keycloak/settings.py
+++ b/invenio_oauthclient/contrib/keycloak/settings.py
@@ -32,11 +32,16 @@ class KeycloakSettingsHelper(OAuthSettingsHelper):
     def __init__(
         self, title, base_url, no_url_modification=False, description=None, realm=None, app_key=None, icon=None, **kwargs
     ):
-        """The constructor takes two arguments.
-
+        """The constructor takes two required arguments, title and base_url. Addtionall parameters can be passed to the constructor to override the default values.
+        
+        :param title: The title of the client application
         :param base_url: The base URL on which Keycloak is running
                             (e.g. "http://localhost:8080")
+        :param no_url_modification: If True, the URL will only consist of the base URL and endpoint
+        :description: The description of the client application
         :param realm: Realm in which the invenio client application is defined
+        :param app_key: The key to use for the client application credentials
+        :param icon: The icon to use for the client application
         """
         app_key = app_key or "KEYCLOAK_APP_CREDENTIALS"
         base_url = "{}/".format(base_url.rstrip("/"))  # add leading `/`

--- a/invenio_oauthclient/contrib/keycloak/settings.py
+++ b/invenio_oauthclient/contrib/keycloak/settings.py
@@ -30,7 +30,7 @@ class KeycloakSettingsHelper(OAuthSettingsHelper):
     """
 
     def __init__(
-        self, title, description, base_url, realm=None, app_key=None, icon=None, **kwargs
+        self, title, base_url, description=None, realm=None, app_key=None, icon=None, **kwargs
     ):
         """The constructor takes two arguments.
 

--- a/invenio_oauthclient/contrib/keycloak/settings.py
+++ b/invenio_oauthclient/contrib/keycloak/settings.py
@@ -30,7 +30,7 @@ class KeycloakSettingsHelper(OAuthSettingsHelper):
     """
 
     def __init__(
-        self, title, description, base_url, realm, app_key=None, icon=None, **kwargs
+        self, title, description, base_url, realm=None, app_key=None, icon=None, **kwargs
     ):
         """The constructor takes two arguments.
 
@@ -41,7 +41,10 @@ class KeycloakSettingsHelper(OAuthSettingsHelper):
         app_key = app_key or "KEYCLOAK_APP_CREDENTIALS"
         base_url = "{}/".format(base_url.rstrip("/"))  # add leading `/`
 
-        self._realm_url = "{}auth/realms/{}".format(base_url, realm)
+        if realm is None:
+            self._realm_url = base_url.rstrip("/")
+        else:
+            self._realm_url = "{}auth/realms/{}".format(base_url, realm)
 
         access_token_url = self.make_url(self._realm_url, "token")
         authorize_url = self.make_url(self._realm_url, "auth")

--- a/invenio_oauthclient/contrib/keycloak/settings.py
+++ b/invenio_oauthclient/contrib/keycloak/settings.py
@@ -30,7 +30,7 @@ class KeycloakSettingsHelper(OAuthSettingsHelper):
     """
 
     def __init__(
-        self, title, base_url, description=None, realm=None, app_key=None, icon=None, **kwargs
+        self, title, base_url, no_url_modification=False, description=None, realm=None, app_key=None, icon=None, **kwargs
     ):
         """The constructor takes two arguments.
 
@@ -46,9 +46,9 @@ class KeycloakSettingsHelper(OAuthSettingsHelper):
         else:
             self._realm_url = "{}auth/realms/{}".format(base_url, realm)
 
-        access_token_url = self.make_url(self._realm_url, "token")
-        authorize_url = self.make_url(self._realm_url, "auth")
-        self._user_info_url = self.make_url(self._realm_url, "userinfo")
+        access_token_url = self.make_url(self._realm_url, "token", no_url_modification)
+        authorize_url = self.make_url(self._realm_url, "auth", no_url_modification)
+        self._user_info_url = self.make_url(self._realm_url, "userinfo", no_url_modification)
 
         super().__init__(
             title,
@@ -102,13 +102,16 @@ class KeycloakSettingsHelper(OAuthSettingsHelper):
         return self._realm_url
 
     @staticmethod
-    def make_url(realm_url, endpoint):
+    def make_url(realm_url, endpoint, no_url_modification):
         """Create an endpoint URL following the default Keycloak URL schema.
 
         :param realm_url: The realm base URL
         :param endpoint: The endpoint to use (e.g. "auth", "token", ...)
         """
-        return "{}/protocol/openid-connect/{}".format(realm_url, endpoint)
+        if no_url_modification is False:
+            return "{}/protocol/openid-connect/{}".format(realm_url, endpoint)
+        else:
+            return"{}/{}".format(realm_url, endpoint)
 
     def get_handlers(self):
         """Return a dict with the auth handlers."""

--- a/invenio_oauthclient/contrib/keycloak/settings.py
+++ b/invenio_oauthclient/contrib/keycloak/settings.py
@@ -103,10 +103,11 @@ class KeycloakSettingsHelper(OAuthSettingsHelper):
 
     @staticmethod
     def make_url(realm_url, endpoint, no_url_modification):
-        """Create an endpoint URL following the default Keycloak URL schema.
-
+        """Create an endpoint URL following the default Keycloak URL schema, with the option to disable URL modification and only use the base URL and endpoint.
+        
         :param realm_url: The realm base URL
         :param endpoint: The endpoint to use (e.g. "auth", "token", ...)
+        :param no_url_modification: If True, the URL will only consist of the base URL and endpoint
         """
         if no_url_modification is False:
             return "{}/protocol/openid-connect/{}".format(realm_url, endpoint)


### PR DESCRIPTION
fixes #293

:heart: Thank you for your contribution!

### Description

This PR should allow the usage of the `KeycloakSettingsHelper` without a realm and also provide the option to use just the `base_url` together with the `endpoint` in the `make_url` function. For further practicality, `description` in the `KeycloakSettingsHelper` is also set as an optional argument.

The above changes enable broader use of the Keycloak `contrib`, as some IAM services e.g. https://github.com/indigo-iam/iam do not use realms, as they are not multi-tenant or Keycloak based.

This change does not affect the use of the package in the *old* way but only introduces new options to omit `realm` and `protocol/openid-connect` in the URL.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
