### PR TITLE
global: explicitly set and use hide attribute for config

### DIFF
--- a/invenio_oauthclient/contrib/settings.py
+++ b/invenio_oauthclient/contrib/settings.py
@@ -8,6 +8,7 @@
 """Common OAuth configuration helper."""
 
 from werkzeug import cached_property
+from werkzeug.local import LocalProxy
 
 
 class OAuthSettingsHelper:
@@ -31,6 +32,7 @@ class OAuthSettingsHelper:
         precedence_mask=None,
         signup_options=None,
         logout_url=None,
+        hide_when=False,
         **kwargs,
     ):
         """The constructor."""
@@ -51,6 +53,7 @@ class OAuthSettingsHelper:
         signup_options = signup_options or {}
         signup_options.setdefault("auto_confirm", True)
         signup_options.setdefault("send_register_msg", False)
+        self.hide_when = hide_when if hide_when is not None else False
 
         self.base_app = dict(
             title=title,
@@ -59,6 +62,9 @@ class OAuthSettingsHelper:
             precedence_mask=precedence_mask,
             signup_options=signup_options,
             logout_url=logout_url,
+            hide=LocalProxy(
+                lambda: self.hide_when() if callable(hide_when) else self.hide_when
+            ),
             params=dict(
                 base_url=self.base_url,
                 request_token_params=request_token_params,

--- a/invenio_oauthclient/templates/invenio_oauthclient/login_user.html
+++ b/invenio_oauthclient/templates/invenio_oauthclient/login_user.html
@@ -14,7 +14,7 @@
 
 {%- block form_outer %}
   {% if config.OAUTHCLIENT_REMOTE_APPS %}
-    {% for name in config.OAUTHCLIENT_REMOTE_APPS.keys() %}
+    {% for name, config in config.OAUTHCLIENT_REMOTE_APPS.items() if not config.hide %}
       {{ oauth_button(name, next=request.args.get('next')) }}
     {% endfor %}
     {%- if config.ACCOUNTS_LOCAL_LOGIN_ENABLED %}

--- a/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/login_user.html
+++ b/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/login_user.html
@@ -16,7 +16,7 @@
 {%- block form_outer %}
   {% if config.OAUTHCLIENT_REMOTE_APPS %}
   <div class="ui form">
-    {% for name in config.OAUTHCLIENT_REMOTE_APPS.keys() %}
+    {% for name, config in config.OAUTHCLIENT_REMOTE_APPS.items() if not config.hide %}
       {{ oauth_button(name, next=request.args.get('next')) }}
     {% endfor %}
   </div>

--- a/invenio_oauthclient/views/client.py
+++ b/invenio_oauthclient/views/client.py
@@ -60,12 +60,19 @@ def auto_redirect_login(*args, **kwargs):
     )
     would_redirect = auto_redirect_enabled and not local_login_enabled
     remote_apps = list(current_oauthclient.oauth.remote_apps)
+    remote_app_configs = current_app.config["OAUTHCLIENT_REMOTE_APPS"]
 
-    if would_redirect and len(remote_apps) == 1:
+    visible_remote_apps = [
+        remote_app
+        for remote_app in remote_apps
+        if remote_app_configs.get(remote_app, {}).get("hide", False)
+    ]
+
+    if would_redirect and len(visible_remote_apps) == 1:
         redirect_args = {
             # if local login is disabled and we only have one OAuth2 remote app
             # configured, we forward directly to that
-            "remote_app": remote_apps[0],
+            "remote_app": visible_remote_apps[0],
         }
         next_url = request.args.get("next")
         if next_url:
@@ -109,6 +116,13 @@ def _login(remote_app, authorized_view_name):
 @blueprint.route("/login/<remote_app>/")
 def login(remote_app):
     """Send user to remote application for authentication."""
+    if (
+        current_app.config["OAUTHCLIENT_REMOTE_APPS"]
+        .get(remote_app, {})
+        .get("hide", False)
+    ):
+        abort(404)
+
     try:
         return _login(remote_app, ".authorized")
     except OAuthRemoteNotFound:
@@ -118,6 +132,13 @@ def login(remote_app):
 @rest_blueprint.route("/login/<remote_app>/")
 def rest_login(remote_app):
     """Send user to remote application for authentication."""
+    if (
+        current_app.config["OAUTHCLIENT_REST_REMOTE_APPS"]
+        .get(remote_app, {})
+        .get("hide", False)
+    ):
+        abort(404)
+
     try:
         return _login(remote_app, ".rest_authorized")
     except OAuthRemoteNotFound:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,6 +335,11 @@ def views_fixture(base_app, params, models_fixture):
                 params=params("fullid"),
                 title="Full",
             ),
+            hidden=dict(
+                params=params("hiddenid"),
+                title="Hidden",
+                hide=True,
+            ),
         )
     )
 
@@ -371,6 +376,15 @@ def views_fixture_rest(base_app, params, models_fixture):
                 signup_redirect_url="/",
                 error_redirect_url="/",
                 title="Full",
+            ),
+            hidden=dict(
+                params=params("hiddenid"),
+                authorized_redirect_url="/",
+                disconnect_redirect_url="/",
+                signup_redirect_url="/",
+                error_redirect_url="/",
+                title="Hidden",
+                hide=True,
             ),
         )
     )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -119,6 +119,12 @@ def test_login(views_fixture):
         resp = client.get(url_for("invenio_oauthclient.login", remote_app="invalid"))
         assert resp.status_code == 404
 
+        # Hidden remote
+        resp = client.get(
+            url_for("invenio_oauthclient.login", remote_app="hidden", next="/")
+        )
+        assert resp.status_code == 404
+
 
 def test_authorized(base_app, params):
     """Test login."""


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

A `hide` attribute is accessed at some places within the existing code already. These changes will explicitly set this attribute and use it in other places in the code as well. This will allow to hide login with an external account, while at the same time, allow to link an external account in the profile view.

Per default, `hide` will evaluate to `False` in order to be compliant with the current logic.


Example config:
```py

def anon_user():
    return not current_user.is_authenticated

helper = k.KeycloakSettingsHelper(
    title="Local KeyCloak",
    description="My organization authentication provider",
    base_url="http://localhost:8087",
    realm="damap",
    # hide_when=anon_user
)

OAUTHCLIENT_REMOTE_APPS = dict(
    orcid={
        **orcid.REMOTE_APP,
        "hide": LocalProxy(lambda: anon_user()),
    },
    keycloak={
        **helper.remote_app,
    },
)
```

Login only via local keycloak:
![image](https://github.com/inveniosoftware/invenio-oauthclient/assets/72449192/82a20898-c0f6-40cc-899d-b20714693057)

Linking of accounts with ORCID also possible:
![image](https://github.com/inveniosoftware/invenio-oauthclient/assets/72449192/d5c0e175-609c-44d1-a494-89ea1c62f426)




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
