### PR TITLE
OAuth2 Token refresh implemented

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@
 Changes
 =======
 
+Version v6.1.0 (released 2025-XX-XX)
+
+- feat: support for refresh tokens
+- feat: link-only remotes
+
 Version v6.0.0 (released 2025-11-03)
 
 - perf(models): changed SQL column type of `extra_data` to `JSONB` instead of `JSON` for PostgreSQL

--- a/invenio_oauthclient/__init__.py
+++ b/invenio_oauthclient/__init__.py
@@ -14,7 +14,7 @@ from .ext import InvenioOAuthClient, InvenioOAuthClientREST
 from .oauth import oauth_link_external_id, oauth_unlink_external_id
 from .proxies import current_oauthclient
 
-__version__ = "6.0.0"
+__version__ = "6.1.0"
 
 __all__ = (
     "__version__",

--- a/invenio_oauthclient/alembic/1758275763_extra_data_jsonb.py
+++ b/invenio_oauthclient/alembic/1758275763_extra_data_jsonb.py
@@ -1,6 +1,7 @@
+# -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2025 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_oauthclient/alembic/7def990b852e_add_expires_at_and_refresh_token_to_.py
+++ b/invenio_oauthclient/alembic/7def990b852e_add_expires_at_and_refresh_token_to_.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2025 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Add expires and refresh_token to remote token."""
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = "7def990b852e"
+down_revision = "1758275763"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.add_column(
+        "oauthclient_remotetoken",
+        sa.Column(
+            "refresh_token", sqlalchemy_utils.StringEncryptedType(), nullable=True
+        ),
+    )
+    op.add_column(
+        "oauthclient_remotetoken",
+        # We are using `created` and `updated` so it should be `expires` and not `expires_at`
+        sa.Column(
+            "expires",
+            sa.DateTime().with_variant(mysql.DATETIME(fsp=6), "mysql"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.drop_column("oauthclient_remotetoken", "expires")
+    op.drop_column("oauthclient_remotetoken", "refresh_token")

--- a/invenio_oauthclient/alembic/__init__.py
+++ b/invenio_oauthclient/alembic/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Alembic migrations for Invenio-OAuthClient."""

--- a/invenio_oauthclient/alembic/aaa265b0afa6_move_useridentity_to_acconuts.py
+++ b/invenio_oauthclient/alembic/aaa265b0afa6_move_useridentity_to_acconuts.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2018 CERN.

--- a/invenio_oauthclient/config.py
+++ b/invenio_oauthclient/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2025 CERN.
 # Copyright (C)      2021 TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
@@ -356,4 +356,10 @@ If this option is enabled and there is exactly one external authentication
 service enabled (i.e. one OAuthClient remote app is configured, and local
 login is disabled), the login view function will automatically redirect to
 that external authentication service.
+"""
+
+OAUTHCLIENT_TOKEN_EXPIRES_LEEWAY = 10
+"""The number of seconds before the actual expiration of an access token from which it is considered expired.
+
+This ensures that it won't cause issues if some time passes between the check for whether the token is expired and any requests that the token is then used in.
 """

--- a/invenio_oauthclient/handlers/__init__.py
+++ b/invenio_oauthclient/handlers/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2019 CERN.
+# Copyright (C) 2015-2025 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_oauthclient/handlers/authorized.py
+++ b/invenio_oauthclient/handlers/authorized.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2023 CERN.
+# Copyright (C) 2023-2025 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -198,6 +198,7 @@ def extra_signup_handler(remote, form, *args, **kwargs):
     oauth_token = token_getter(remote)
     if not oauth_token:
         raise OAuthClientTokenNotFound()
+    access_token, secret, refresh_token, expires = oauth_token
 
     session_prefix = token_session_key(remote.name)
 
@@ -211,7 +212,14 @@ def extra_signup_handler(remote, form, *args, **kwargs):
         user = _register_user(response, remote, account_info, form)
 
         # Link account and set session data
-        token = token_setter(remote, oauth_token[0], secret=oauth_token[1], user=user)
+        token = token_setter(
+            remote,
+            access_token,
+            secret=secret,
+            user=user,
+            refresh_token=refresh_token,
+            expires=expires,
+        )
         if token is None:
             raise OAuthClientTokenNotSet()
 

--- a/invenio_oauthclient/handlers/refresh.py
+++ b/invenio_oauthclient/handlers/refresh.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2024 CESNET z.s.p.o.
+# Copyright (C) 2025 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Handler for refreshing access token."""
+
+from flask_oauthlib.client import OAuthResponse
+from flask_oauthlib.utils import to_bytes
+
+from invenio_oauthclient.handlers.token import make_expiration_time
+
+from ..models import RemoteToken
+from ..proxies import current_oauthclient
+
+
+def refresh_access_token(token: RemoteToken):
+    """
+    Internal method to refresh the access token (via RFC 6749 Section 6).
+
+    :param token: the remote token to be refreshed
+    :returns tuple of (access_token, refresh_token, expires)
+
+    Note: the current access/refresh token are invalidated during this call
+    """
+    remote_account = token.remote_account
+    client_id = remote_account.client_id
+    # Find the remote by client ID
+    remote = next(
+        x
+        for x in current_oauthclient.oauth.remote_apps.values()
+        if x.consumer_key == client_id
+    )
+    client = remote.make_client()
+    request_url, request_headers, request_body = client.prepare_refresh_token_request(
+        remote.access_token_url,
+        refresh_token=token.refresh_token,
+        client_id=remote.consumer_key,
+        client_secret=remote.consumer_secret,
+    )
+    resp, content = remote.http_request(
+        request_url,
+        request_headers,
+        data=to_bytes(request_body, remote.encoding),
+        method="POST",
+    )
+    resp = OAuthResponse(resp, content, remote.content_type)
+    return (
+        resp.data.get("access_token"),
+        # As per the RFC, the server MAY issue a new refresh token of an identical scope, which we must save.
+        resp.data.get("refresh_token"),
+        make_expiration_time(resp.data.get("expires_in")),
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2025 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -38,6 +38,11 @@ def mock_response(oauth, remote_app="test", data=None):
 def mock_remote_get(oauth, remote_app="test", data=None):
     """Mock the oauth remote get response."""
     oauth.remote_apps[remote_app].get = MagicMock(return_value=data)
+
+
+def mock_remote_http_request(oauth, remote_app="test", data=None):
+    """Mock the oauth remote get response."""
+    oauth.remote_apps[remote_app].http_request = MagicMock(return_value=data)
 
 
 def check_redirect_location(resp, loc):

--- a/tests/test_base_handlers.py
+++ b/tests/test_base_handlers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2016-2025 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -51,4 +51,4 @@ def test_token_getter(remote, models_fixture, app):
     # Populated RemoteToken
     RemoteToken.create(user.id, "testkey", "mytoken", "mysecret")
     oauth_authenticate("dev", user)
-    assert token_getter(remote) == ("mytoken", "mysecret")
+    assert token_getter(remote) == ("mytoken", "mysecret", None, None)

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2024 CESNET z.s.p.o.
+# Copyright (C) 2025 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test handlers."""
+import json
+from datetime import datetime, timezone
+
+from helpers import mock_remote_http_request
+
+from invenio_oauthclient.models import RemoteToken
+
+
+def test_refresh(models_fixture, app):
+    """Test token getter on response from OAuth server."""
+    datastore = app.extensions["invenio-accounts"].datastore
+    existing_email = "existing@inveniosoftware.org"
+    user = datastore.find_user(email=existing_email)
+
+    rt = RemoteToken.create(
+        user.id,
+        "cern_key_changeme",
+        "mytoken",
+        "mysecret",
+        refresh_token="myrefreshtoken",
+        expires=datetime.now(tz=timezone.utc),
+    )
+    assert rt.is_expired is True
+
+    ioc = app.extensions["oauthlib.client"]
+    mock_remote_http_request(
+        ioc,
+        "cern_openid",
+        [
+            None,
+            json.dumps(
+                {
+                    "access_token": "newtoken",
+                    "token_type": "bearer",
+                    "expires_in": 1199,
+                    "refresh_token": "newrefreshtoken",
+                }
+            ),
+        ],
+    )
+
+    rt.refresh_access_token()
+    assert rt.is_expired is False
+    assert rt.access_token == "newtoken"
+    assert rt.refresh_token == "newrefreshtoken"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2025 CERN.
 # Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
@@ -398,7 +398,12 @@ def test_token_getter_setter(views_fixture, monkeypatch):
         # Assert if everything is as it should be.
         from flask import session as flask_session
 
-        assert flask_session["oauth_token_full"] == ("test_access_token", "")
+        assert flask_session["oauth_token_full"] == (
+            "test_access_token",
+            "",
+            None,
+            None,
+        )
 
         t = RemoteToken.get(1, "fullid")
         assert t.remote_account.client_id == "fullid"
@@ -430,7 +435,7 @@ def test_token_getter_setter(views_fixture, monkeypatch):
         assert RemoteToken.query.count() == 1
 
         val = token_getter(app.extensions["oauthlib.client"].remote_apps["full"])
-        assert val == ("new_access_token", "")
+        assert val == ("new_access_token", "", None, None)
 
         # Disconnect account
         res = c.get(

--- a/tests/test_views_rest.py
+++ b/tests/test_views_rest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2025 CERN.
 # Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
@@ -386,7 +386,12 @@ def test_token_getter_setter(app_rest, monkeypatch):
         # Assert if everything is as it should be.
         from flask import session as flask_session
 
-        assert flask_session["oauth_token_full"] == ("test_access_token", "")
+        assert flask_session["oauth_token_full"] == (
+            "test_access_token",
+            "",
+            None,
+            None,
+        )
 
         t = RemoteToken.get(1, "fullid")
         assert t.remote_account.client_id == "fullid"
@@ -418,7 +423,7 @@ def test_token_getter_setter(app_rest, monkeypatch):
         assert RemoteToken.query.count() == 1
 
         val = token_getter(app_rest.extensions["oauthlib.client"].remote_apps["full"])
-        assert val == ("new_access_token", "")
+        assert val == ("new_access_token", "", None, None)
 
         # Disconnect account
         res = c.get(


### PR DESCRIPTION
**Important**: we are aiming to release this at the same time as https://github.com/inveniosoftware/invenio-oauthclient/pull/360. When we merge, we need to align the DB migrations, but still keep them as 2 separate migrations so that one can be run manually. This migration does not need to be run manually in any scenario.

### Description

Closes #68.

Added fields on `RemoteToken` model:
* `refresh_token`
* `expires_at`

Added properties on `RemoteToken`:
* `is_expired`

New methods on `RemoteToken`:
* `refresh_access_token`

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
