### PR TITLE
fix: add flag for auth in keycloak realm url

### DIFF
--- a/invenio_oauthclient/contrib/keycloak/settings.py
+++ b/invenio_oauthclient/contrib/keycloak/settings.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020-2021 TU Wien.
+# Copyright (C)      2024 Graz University of Technology.
 #
 # Invenio-Keycloak is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -38,6 +39,7 @@ class KeycloakSettingsHelper(OAuthSettingsHelper):
         app_key=None,
         icon=None,
         scopes="openid",
+        legacy_url_path=True,  # for keycloak versions < 17
         **kwargs
     ):
         """The constructor takes two arguments.
@@ -45,11 +47,18 @@ class KeycloakSettingsHelper(OAuthSettingsHelper):
         :param base_url: The base URL on which Keycloak is running
                             (e.g. "http://localhost:8080")
         :param realm: Realm in which the invenio client application is defined
+        :param leagcy_url_path: Add "/auth/" between the base URL and realm names for generated Keycloak URLs (default: True, for Keycloak up to v17)
         """
         app_key = app_key or "KEYCLOAK_APP_CREDENTIALS"
         base_url = "{}/".format(base_url.rstrip("/"))  # add leading `/`
 
-        self._realm_url = "{}auth/realms/{}".format(base_url, realm)
+        # Keycloak versions < 17 have default realm url of <base_url>/auth/realms/
+        # Newer version omit the /auth portion per default.
+        self._realm_url = "{base_url}{realms_part}/{realm}".format(
+            base_url=base_url,
+            realms_part="auth/realms" if legacy_url_path else "realms",
+            realm=realm,
+        )
 
         access_token_url = self.make_url(self._realm_url, "token")
         authorize_url = self.make_url(self._realm_url, "auth")


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
closes #323 

Add flag for using the `auth/` part in the realm url.
Newer versions of keycloak do not have an `auth/` part in the realm url per default anymore. To not break existing InvenioRDM instances and oauth configurations, the flag is set to true per default.

This allows to keep all the other setup functionality and only modify the realm url if needed.
Keycloak v16 support has been deprecated for quite some time now ((11 Mar 2022) according to https://endoflife.date/keycloak).

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
