### PR TITLE
views: fix boolean logic for checking remote app visibility

### DIFF
--- a/invenio_oauthclient/views/client.py
+++ b/invenio_oauthclient/views/client.py
@@ -65,7 +65,7 @@ def auto_redirect_login(*args, **kwargs):
     visible_remote_apps = [
         remote_app
         for remote_app in remote_apps
-        if remote_app_configs.get(remote_app, {}).get("hide", False)
+        if not remote_app_configs.get(remote_app, {}).get("hide", False)
     ]
 
     if would_redirect and len(visible_remote_apps) == 1:


### PR DESCRIPTION
Previously, the logic did the opposite of what it was supposed to do: It filtered for the *invisible* remote apps