### PR TITLE
Fix: i18n: added gettext to places where it was missing

### DIFF
--- a/invenio_oauthclient/admin.py
+++ b/invenio_oauthclient/admin.py
@@ -10,13 +10,9 @@
 
 from flask_admin.contrib.sqla import ModelView
 from invenio_accounts.admin import user_identity_adminview
+from invenio_i18n import gettext as _
 
 from .models import RemoteAccount, RemoteToken
-
-
-def _(x):
-    """Identity."""
-    return x
 
 
 class RemoteAccountView(ModelView):
@@ -52,11 +48,13 @@ class RemoteAccountView(ModelView):
     column_display_all_relations = True
     inline_models = (RemoteToken,)
 
-    column_labels = {
-        "id": _("ID"),
-        "user_id": _("User ID"),
-        "client_id": _("Client ID"),
-    }
+    @property
+    def column_labels(self):
+        return {
+            "id": _("ID"),
+            "user_id": _("User ID"),
+            "client_id": _("Client ID"),
+        }
 
 
 class RemoteTokenView(ModelView):
@@ -81,9 +79,11 @@ class RemoteTokenView(ModelView):
         "token_type",
     )
 
-    column_labels = {
-        "id_remote_account": _("ID Remote Account"),
-    }
+    @property
+    def column_labels(self):
+        return {
+            "id_remote_account": _("ID Remote Account"),
+        }
 
 
 remote_account_adminview = {

--- a/invenio_oauthclient/contrib/cern.py
+++ b/invenio_oauthclient/contrib/cern.py
@@ -149,6 +149,7 @@ from flask_principal import (
 )
 from invenio_db import db
 from invenio_i18n import gettext as _
+from invenio_i18n import lazy_gettext
 
 from invenio_oauthclient.errors import OAuthCERNRejectedAccountError
 from invenio_oauthclient.handlers.rest import response_handler
@@ -204,8 +205,8 @@ OAUTHCLIENT_CERN_ALLOWED_IDENTITY_CLASSES = ["CERN Registered", "CERN Shared"]
 """Cern oauth identityClass values that are allowed to be used."""
 
 BASE_APP = dict(
-    title="CERN",
-    description="Connecting to CERN Organization.",
+    title=lazy_gettext("CERN"),
+    description=lazy_gettext("Connecting to CERN Organization."),
     icon="",
     logout_url="https://login.cern.ch/adfs/ls/?wa=wsignout1.0",
     params=dict(
@@ -405,8 +406,10 @@ def _account_info(remote, resp):
     identity_class = resource.get("IdentityClass", [None])[0]
     if identity_class is None or identity_class not in valid_identities:
         raise OAuthCERNRejectedAccountError(
-            "Identity class {0} is not one of [{1}]".format(
-                identity_class, "".join(valid_identities)
+            _(
+                "Identity class %(identity_class)s is not one of [%(valid_identities)s]",
+                identity_class=identity_class,
+                valid_identities="".join(valid_identities),
             ),
             remote,
             resp,

--- a/invenio_oauthclient/contrib/cern_openid.py
+++ b/invenio_oauthclient/contrib/cern_openid.py
@@ -77,6 +77,7 @@ from flask_principal import (
 )
 from invenio_db import db
 from invenio_i18n import gettext as _
+from invenio_i18n import lazy_gettext
 from jwt import decode
 
 from invenio_oauthclient.errors import OAuthCERNRejectedAccountError
@@ -99,8 +100,8 @@ OAUTHCLIENT_CERN_OPENID_ALLOWED_ROLES = ["cern_user"]
 """CERN OAuth application role values that are allowed to be used."""
 
 BASE_APP = dict(
-    title="CERN",
-    description="Connecting to CERN Organization.",
+    title=lazy_gettext("CERN"),
+    description=lazy_gettext("Connecting to CERN Organization."),
     icon="",
     logout_url="https://auth.cern.ch/auth/realms/cern/protocol/"
     "openid-connect/logout",
@@ -273,7 +274,11 @@ def _account_info(remote, resp):
     cern_roles = resource.get("cern_roles")
     if cern_roles is None or not set(cern_roles).issubset(valid_roles):
         raise OAuthCERNRejectedAccountError(
-            "User roles {0} are not one of {1}".format(cern_roles, valid_roles),
+            _(
+                "User roles %(cern_roles)s are not one of %(valid_roles)s",
+                cern_roles=cern_roles,
+                valid_roles=valid_roles,
+            ),
             remote,
             resp,
         )

--- a/invenio_oauthclient/contrib/github.py
+++ b/invenio_oauthclient/contrib/github.py
@@ -73,6 +73,7 @@ import github3
 from flask import current_app, redirect, url_for
 from flask_login import current_user
 from invenio_db import db
+from invenio_i18n import lazy_gettext as _
 
 from invenio_oauthclient import current_oauthclient
 from invenio_oauthclient.contrib.settings import OAuthSettingsHelper
@@ -105,8 +106,8 @@ class GitHubOAuthSettingsHelper(OAuthSettingsHelper):
     ):
         """Constructor."""
         super().__init__(
-            title or "GitHub",
-            description or "Software collaboration platform.",
+            title or _("GitHub"),
+            description or _("Software collaboration platform."),
             base_url or "https://api.github.com/",
             app_key or "GITHUB_APP_CREDENTIALS",
             icon=icon or "fa fa-github",
@@ -261,7 +262,7 @@ def authorized(resp, remote):
             return redirect(url_for("invenio_oauthclient.login", remote_app="github"))
         elif resp["error"] in ["incorrect_client_credentials", "redirect_uri_mismatch"]:
             raise OAuthResponseError(
-                "Application mis-configuration in GitHub", remote, resp
+                _("Application mis-configuration in GitHub"), remote, resp
             )
 
     return authorized_signup_handler(resp, remote)
@@ -283,7 +284,7 @@ def authorized_rest(resp, remote):
             )
         elif resp["error"] in ["incorrect_client_credentials", "redirect_uri_mismatch"]:
             raise OAuthResponseError(
-                "Application mis-configuration in GitHub", remote, resp
+                _("Application mis-configuration in GitHub"), remote, resp
             )
 
     return authorized_signup_rest_handler(resp, remote)

--- a/invenio_oauthclient/contrib/globus.py
+++ b/invenio_oauthclient/contrib/globus.py
@@ -67,6 +67,7 @@ you can re-define the default Globus OAuth instance:
 from flask import current_app, redirect, url_for
 from flask_login import current_user
 from invenio_db import db
+from invenio_i18n import lazy_gettext as _
 
 from invenio_oauthclient import current_oauthclient
 from invenio_oauthclient.contrib.settings import OAuthSettingsHelper
@@ -91,8 +92,8 @@ class GlobusOAuthSettingsHelper(OAuthSettingsHelper):
     ):
         """Constructor."""
         super().__init__(
-            title or "Globus",
-            description or "Research data management simplified.",
+            title or _("Globus"),
+            description or _("Research data management simplified."),
             base_url or "https://auth.globus.org/v2/",
             app_key or "GLOBUS_APP_CREDENTIALS",
             request_token_params={"scope": "openid email profile"},
@@ -164,7 +165,7 @@ def get_dict_from_response(response):
     """Check for errors in the response and return the resulting JSON."""
     if getattr(response, "_resp") and response._resp.code > 400:
         raise OAuthResponseError(
-            "Application mis-configuration in Globus", None, response
+            _("Application mis-configuration in Globus"), None, response
         )
 
     return response.data
@@ -199,7 +200,7 @@ def get_user_id(remote, email):
         # If we got here the response was successful but the data was invalid.
         # It's likely the URL is wrong but possible the API has changed.
         raise OAuthResponseError(
-            "Failed to fetch user id, likely server " "mis-configuration", None, remote
+            _("Failed to fetch user id, likely server mis-configuration"), None, remote
         )
 
 

--- a/invenio_oauthclient/contrib/keycloak/helpers.py
+++ b/invenio_oauthclient/contrib/keycloak/helpers.py
@@ -11,6 +11,7 @@ import re
 
 import jwt
 from flask import current_app
+from invenio_i18n import gettext as _
 
 from ...errors import OAuthError, OAuthKeycloakUserInfoError
 
@@ -27,9 +28,12 @@ def _generate_config_prefix(remote):
     app_name = remote.name
     if not is_app_name_valid(app_name):
         raise OAuthError(
-            f"Invalid app name {app_name}. "
-            "It should only contain letters, numbers, dashes "
-            "and underscores",
+            _(
+                "Invalid app name %(app_name)s. "
+                "It should only contain letters, numbers, dashes "
+                "and underscores",
+                app_name=app_name,
+            ),
             remote,
         )
     return f"OAUTHCLIENT_{app_name.upper()}"

--- a/invenio_oauthclient/contrib/openaire_aai.py
+++ b/invenio_oauthclient/contrib/openaire_aai.py
@@ -72,6 +72,7 @@ import jwt
 from flask import current_app, redirect, url_for
 from flask_login import current_user
 from invenio_db import db
+from invenio_i18n import lazy_gettext as _
 
 from invenio_oauthclient import current_oauthclient
 from invenio_oauthclient.contrib.keycloak import KeycloakSettingsHelper
@@ -101,8 +102,8 @@ class OpenAIREAuthSettingsHelper(OAuthSettingsHelper):
             "send_register_msg": True,
         }
         super().__init__(
-            title or "OpenAIRE",
-            description or "Open Science Services.",
+            title or _("OpenAIRE"),
+            description or _("Open Science Services."),
             base_url,
             app_key or "OPENAIRE_APP_CREDENTIALS",
             request_token_params={"scope": "openid profile email orcid"},
@@ -166,8 +167,8 @@ REMOTE_REST_APP = _openaire_aai_app.remote_rest_app
 
 # Sandbox
 _openaire_aai_sandbox_app = KeycloakSettingsHelper(
-    title="OpenAIRE",
-    description="Open Science Services.",
+    title=_("OpenAIRE"),
+    description=_("Open Science Services."),
     base_url="https://beta.aai.openaire.eu",
     realm="openaire",
     scopes="openid profile email eduperson_entitlement orcid",

--- a/invenio_oauthclient/contrib/orcid.py
+++ b/invenio_oauthclient/contrib/orcid.py
@@ -74,6 +74,7 @@ For more details you can play with a :doc:`working example <examplesapp>`.
 from flask import current_app, redirect, url_for
 from flask_login import current_user
 from invenio_db import db
+from invenio_i18n import lazy_gettext as _
 
 from invenio_oauthclient import current_oauthclient
 from invenio_oauthclient.contrib.settings import OAuthSettingsHelper
@@ -109,8 +110,8 @@ class ORCIDOAuthSettingsHelper(OAuthSettingsHelper):
         }
 
         super().__init__(
-            title or "ORCID",
-            description or "Connecting Research and Researchers.",
+            title or _("ORCID"),
+            description or _("Connecting Research and Researchers."),
             base_url or "https://pub.orcid.org/v1.2/",
             app_key or "ORCID_APP_CREDENTIALS",
             request_token_params={"scope": "/authenticate", "show_login": "true"},

--- a/invenio_oauthclient/handlers/__init__.py
+++ b/invenio_oauthclient/handlers/__init__.py
@@ -32,7 +32,9 @@ from .ui import (
     oauth2_handle_error,
 )
 from .ui import oauth_resp_remote_error_handler as oauth_error_handler
-from .ui import signup_handler
+from .ui import (
+    signup_handler,
+)
 from .utils import authorized_handler, make_handler
 
 __all__ = (

--- a/invenio_oauthclient/handlers/rest.py
+++ b/invenio_oauthclient/handlers/rest.py
@@ -23,6 +23,7 @@ from flask import (
 )
 from flask_login import current_user
 from invenio_db import db
+from invenio_i18n import gettext as _
 
 from ..errors import (
     AlreadyLinkedError,
@@ -86,16 +87,20 @@ def _oauth_error_handler(remote, f, *args, **kwargs):
         return response_handler(
             remote,
             remote_app_config["error_redirect_url"],
-            payload=dict(message="Authorization with remote service failed.", code=400),
+            payload=dict(
+                message=_("Authorization with remote service failed."), code=400
+            ),
         )
     except OAuthRejectedRequestError:
         return response_handler(
             remote,
             remote_app_config["error_redirect_url"],
-            payload=dict(message="You rejected the authentication request.", code=400),
+            payload=dict(
+                message=_("You rejected the authentication request."), code=400
+            ),
         )
     except AlreadyLinkedError:
-        msg = "External service is already linked to another account."
+        msg = _("External service is already linked to another account.")
         return response_handler(
             remote,
             remote_app_config["error_redirect_url"],
@@ -105,14 +110,14 @@ def _oauth_error_handler(remote, f, *args, **kwargs):
         return response_handler(
             remote,
             remote_app_config["error_redirect_url"],
-            payload=dict(message="Unauthorized.", code=401),
+            payload=dict(message=_("Unauthorized."), code=401),
         )
     except OAuthClientAlreadyAuthorized:
         return response_handler(
             remote,
             remote_app_config["authorized_redirect_url"],
             payload=dict(
-                message="Successfully signed up.",
+                message=_("Successfully signed up."),
                 code=200,
             ),
         )
@@ -121,14 +126,14 @@ def _oauth_error_handler(remote, f, *args, **kwargs):
             remote,
             remote_app_config["error_redirect_url"],
             payload=dict(
-                message="Token not found.",
+                message=_("Token not found."),
                 code=400,
             ),
         )
     except OAuthClientUserNotRegistered:
         abort(make_response(jsonify(message="Form validation error."), 400))
     except OAuthClientTokenNotSet:
-        raise OAuthError("Could not create token for user.", remote)
+        raise OAuthError(_("Could not create token for user."), remote)
     except OAuthClientMustRedirectSignup as e:
         return redirect(
             url_for(
@@ -208,7 +213,7 @@ def authorized_signup_handler(resp, remote, *args, **kwargs):
     """
     remote_app_config = current_app.config["OAUTHCLIENT_REST_REMOTE_APPS"][remote.name]
     next_url = authorized_handler(resp, remote, *args, **kwargs)
-    response_payload = dict(message="Successfully authorized.", code=200)
+    response_payload = dict(message=_("Successfully authorized."), code=200)
     if next_url:
         response_payload["next_url"] = next_url
 
@@ -238,7 +243,7 @@ def disconnect_handler(remote, *args, **kwargs):
         remote,
         redirect_url,
         payload=dict(
-            message="Successfully disconnected.",
+            message=_("Successfully disconnected."),
             code=200,
         ),
     )
@@ -282,7 +287,7 @@ def signup_handler(remote, *args, **kwargs):
         except OAuthClientUnAuthorized:
             abort(401)
 
-        response_payload = dict(message="Successfully signed up.", code=200)
+        response_payload = dict(message=_("Successfully signed up."), code=200)
         if next_url:
             response_payload["next_url"] = next_url
         return jsonify(response_payload)

--- a/invenio_oauthclient/handlers/token.py
+++ b/invenio_oauthclient/handlers/token.py
@@ -13,6 +13,7 @@ from functools import partial
 from flask import current_app, session
 from flask_login import current_user
 from invenio_db import db
+from invenio_i18n import gettext as _
 
 from ..errors import OAuthClientError, OAuthRejectedRequestError, OAuthResponseError
 from ..models import RemoteToken
@@ -58,7 +59,7 @@ def response_token_setter(remote, resp):
     :returns: The token.
     """
     if resp is None:
-        raise OAuthRejectedRequestError("User rejected request.", remote, resp)
+        raise OAuthRejectedRequestError(_("User rejected request."), remote, resp)
     else:
         if "access_token" in resp:
             return oauth2_token_setter(remote, resp)
@@ -67,11 +68,11 @@ def response_token_setter(remote, resp):
         elif "error" in resp:
             # Only OAuth2 specifies how to send error messages
             raise OAuthClientError(
-                "Authorization with remote service failed.",
+                _("Authorization with remote service failed."),
                 remote,
                 resp,
             )
-    raise OAuthResponseError("Bad OAuth authorized request", remote, resp)
+    raise OAuthResponseError(_("Bad OAuth authorized request"), remote, resp)
 
 
 def oauth1_token_setter(remote, resp, token_type="", extra_data=None):

--- a/invenio_oauthclient/handlers/ui.py
+++ b/invenio_oauthclient/handlers/ui.py
@@ -154,7 +154,9 @@ def authorized_signup_handler(resp, remote, *args, **kwargs):
         do_flash(
             Markup(
                 _(
-                    f"A confirmation email has already been sent to {exc.user.email}. Didn't receive it? Click <strong><a href=\"{url_for('security.send_confirmation')}\">here</a></strong> to resend it."
+                    'A confirmation email has already been sent to %(email)s. Didn\'t receive it? Click <strong><a href="%(url)s">here</a></strong> to resend it.',
+                    email=exc.user.email,
+                    url=url_for("security.send_confirmation"),
                 )
             ),
             category="success",

--- a/invenio_oauthclient/handlers/utils.py
+++ b/invenio_oauthclient/handlers/utils.py
@@ -15,6 +15,7 @@ from flask_login import current_user
 from invenio_accounts.models import Role
 from invenio_accounts.proxies import current_datastore
 from invenio_db import db
+from invenio_i18n import gettext as _
 from werkzeug.utils import import_string
 
 from ..models import RemoteAccount
@@ -121,14 +122,20 @@ def create_or_update_roles(groups, persist_every=500):
             existing_role = current_datastore.find_role_by_id(group["id"])
             if existing_role and existing_role.is_managed:
                 current_app.logger.exception(
-                    f'Error while syncing roles: A managed role with id: {group["id"]} already exists'
+                    _(
+                        "Error while syncing roles: A managed role with id: %(group_id)s already exists",
+                        group_id=group["id"],
+                    )
                 )
                 continue
 
             existing_role_by_name = current_datastore.find_role(group["name"])
             if existing_role_by_name and existing_role_by_name.is_managed:
                 current_app.logger.exception(
-                    f'Error while syncing roles: A managed role with name: {group["name"]} already exists'
+                    _(
+                        "Error while syncing roles: A managed role with name: %(group_name)s already exists",
+                        group_name=group["name"],
+                    )
                 )
                 continue
 

--- a/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/login_user.html
+++ b/invenio_oauthclient/templates/semantic-ui/invenio_oauthclient/login_user.html
@@ -23,7 +23,7 @@
 
     {%- if config.ACCOUNTS_LOCAL_LOGIN_ENABLED %}
       <div class="ui horizontal divider">
-        {{ _("Or") }}
+        {{ _("OR") }}
       </div>
     {%- endif %}
   {% endif %}

--- a/tests/test_contrib_keycloak.py
+++ b/tests/test_contrib_keycloak.py
@@ -419,7 +419,7 @@ def test_get_userinfo_from_endpoint(
         assert user_info == example_keycloak_userinfo.data
 
 
-def test_raise_on_invalid_app_name():
+def test_raise_on_invalid_app_name(app):
     """Test that the app name format is validated."""
 
     class FakeRemote:


### PR DESCRIPTION
### Description

Fix: some strings that could appear inside UI were not marked with `gettext/lazy_gettext`. 

This PR adds `lazy_gettext` into places where the string is read when invenio is started (static initialization) and `gettext` elsewhere

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
