### PR TITLE
fix(chore): DeprecationWarning stdlib

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -34,4 +34,4 @@ jobs:
   Tests:
     uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master
     with:
-      extras: "tests"
+      extras: "tests,admin"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@
 Changes
 =======
 
+Version v7.0.0 (released 2026-01-29)
+
+- chore(tests): add admin
+- chore(setup): bump dependencies
+- fix(chore): DeprecationWarning stdlib
+
 Version v6.1.2 (released 2026-01-27)
 
 - chore(black): update formatting to >= 26.0

--- a/invenio_oauthclient/__init__.py
+++ b/invenio_oauthclient/__init__.py
@@ -14,7 +14,7 @@ from .ext import InvenioOAuthClient, InvenioOAuthClientREST
 from .oauth import oauth_link_external_id, oauth_unlink_external_id
 from .proxies import current_oauthclient
 
-__version__ = "6.1.2"
+__version__ = "7.0.0"
 
 __all__ = (
     "__version__",

--- a/invenio_oauthclient/alembic/edf0c0907f40_change_datetime_types.py
+++ b/invenio_oauthclient/alembic/edf0c0907f40_change_datetime_types.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2025 CERN.
+# Copyright (C) 2026 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Alter datetime columns to utc aware datetime columns."""
+
+from invenio_db.utils import (
+    update_table_columns_column_type_to_datetime,
+    update_table_columns_column_type_to_utc_datetime,
+)
+
+# revision identifiers, used by Alembic.
+revision = "edf0c0907f40"
+down_revision = "7def990b852e"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    for table_name in ["oauthclient_remoteaccount", "oauthclient_remotetoken"]:
+        update_table_columns_column_type_to_utc_datetime(table_name, "created")
+        update_table_columns_column_type_to_utc_datetime(table_name, "updated")
+    update_table_columns_column_type_to_utc_datetime(
+        "oauthclient_remotetoken", "expires"
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    for table_name in ["oauthclient_remoteaccount", "oauthclient_remotetoken"]:
+        update_table_columns_column_type_to_datetime(table_name, "created")
+        update_table_columns_column_type_to_datetime(table_name, "updated")
+    update_table_columns_column_type_to_datetime("oauthclient_remotetoken", "expires")

--- a/invenio_oauthclient/contrib/cern.py
+++ b/invenio_oauthclient/contrib/cern.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -135,7 +136,7 @@ For more details you can play with a :doc:`working example <examplesapp>`.
 
 import copy
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from warnings import warn
 
 from flask import Blueprint, current_app, flash, g, redirect, session, url_for
@@ -332,7 +333,7 @@ def fetch_extra_data(resource):
 
 def account_groups_and_extra_data(account, resource, refresh_timedelta=None):
     """Fetch account groups and extra data from resource if necessary."""
-    updated = datetime.utcnow()
+    updated = datetime.now(timezone.utc)
     modified_since = updated
     if refresh_timedelta is not None:
         modified_since += refresh_timedelta

--- a/invenio_oauthclient/contrib/cern_openid.py
+++ b/invenio_oauthclient/contrib/cern_openid.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2023 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -64,7 +65,7 @@ In templates you can add a sign in/up link:
     </a>
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, current_app, flash, g, redirect, session, url_for
 from flask_login import current_user
@@ -187,7 +188,7 @@ def fetch_extra_data(resource):
 
 def account_roles_and_extra_data(account, resource, refresh_timedelta=None):
     """Fetch account roles and extra data from resource if necessary."""
-    updated = datetime.utcnow()
+    updated = datetime.now(timezone.utc)
     modified_since = updated
     if refresh_timedelta is not None:
         modified_since += refresh_timedelta

--- a/invenio_oauthclient/models.py
+++ b/invenio_oauthclient/models.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2025 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -21,7 +21,7 @@ from invenio_db import db
 from sqlalchemy.dialects import mysql, postgresql
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import backref
-from sqlalchemy_utils import JSONType, StringEncryptedType, Timestamp
+from sqlalchemy_utils import JSONType, StringEncryptedType
 
 
 def _secret_key():
@@ -29,7 +29,7 @@ def _secret_key():
     return current_app.config["SECRET_KEY"]
 
 
-class RemoteAccount(db.Model, Timestamp):
+class RemoteAccount(db.Model, db.Timestamp):
     """Storage for remote linked accounts."""
 
     __tablename__ = "oauthclient_remoteaccount"
@@ -105,7 +105,7 @@ class RemoteAccount(db.Model, Timestamp):
         return "Remote Account <id={0.id}, user_id={0.user.id}>".format(self)
 
 
-class RemoteToken(db.Model, Timestamp):
+class RemoteToken(db.Model, db.Timestamp):
     """Storage for the access tokens for linked accounts."""
 
     __tablename__ = "oauthclient_remotetoken"
@@ -136,9 +136,7 @@ class RemoteToken(db.Model, Timestamp):
     )
     """Refresh token to remote application."""
 
-    expires = db.Column(
-        db.DateTime().with_variant(mysql.DATETIME(fsp=6), "mysql"), nullable=True
-    )
+    expires = db.Column(db.UTCDateTime(), nullable=True)
     """Access token expiration date."""
 
     secret = db.Column(db.Text(), default="", nullable=False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     blinker>=1.4
-    Flask-OAuthlib-Invenio>=1.0.0,<2.0.0
-    invenio-accounts>=6.0.0,<7.0.0
+    Flask-OAuthlib-Invenio>=2.0.0,<3.0.0
+    invenio-accounts>=7.0.0,<8.0.0
     invenio-base>=2.0.0,<3.0.0
     invenio-i18n>=3.0.0,<4.0.0
     invenio-mail>=1.0.2,<3.0.0
@@ -44,16 +44,16 @@ install_requires =
 [options.extras_require]
 tests =
     flask_admin>=1.6.0
-    pytest-black-ng>=0.4.0
+    pytest-black>=0.6.0
     httpretty>=0.8.14
-    invenio-userprofiles>=4.0.0,<5.0.0
+    invenio-userprofiles>=5.0.0,<6.0.0
     mock>=1.3.0
     oauthlib>=1.1.2
-    pytest-invenio>=3.0.0,<4.0.0
+    pytest-invenio>=4.0.0,<5.0.0
     requests-oauthlib>=0.6.2
     simplejson>=3.8
     sphinx>=4.5
-    invenio-db[mysql,postgresql,versioning]>=2.0.0,<3.0.0
+    invenio-db[mysql,postgresql,versioning]>=2.2.0,<3.0.0
 
 # Kept for backwards compatibility
 admin =

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,9 +54,10 @@ tests =
     simplejson>=3.8
     sphinx>=4.5
     invenio-db[mysql,postgresql,versioning]>=2.2.0,<3.0.0
+admin =
+    invenio-accounts[admin]>=7.0.0,<8.0.0
 
 # Kept for backwards compatibility
-admin =
 docs =
 github =
 mysql =


### PR DESCRIPTION
* datetime.datetime.utcnow() is deprecated and scheduled for removal in
  a future version. Use timezone-aware objects to represent datetimes in
  UTC: datetime.datetime.now(datetime.UTC).

* the decision was made to move to utc aware timestamps
