### PR TITLE
fix(refresh): allow non-compliant access token response type

### DIFF
--- a/invenio_oauthclient/handlers/token.py
+++ b/invenio_oauthclient/handlers/token.py
@@ -125,6 +125,16 @@ def make_expiration_time(expires_in):
     """
     if expires_in is None:
         return None
+
+    if isinstance(expires_in, str):
+        # RFC 6749 5.1 requires the response type to the access token request to be application/json.
+        # However, some non-compliant implementations (e.g. GitHub) instead use application/x-www-form-urlencoded.
+        # This only supports strings, so the response dict is coerced into strings. We need to convert
+        # `expires_in` (the only int parameter) back into an int.
+        expires_in = int(expires_in)
+
+    # Just in case any other unexpected types might have come out of the parser
+    assert isinstance(expires_in, int)
     return datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in)
 
 


### PR DESCRIPTION
* Fixed an error with non-compliant OAuth providers that return a refresh token, which we added support for in #328.

* GitHub (when using ["GitHub Apps" instead of "OAuth Apps"](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps)) and a small number of other implementations violate [RFC 6749 5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1) by returning a default response type of `application/x-www-form-urlencoded` for the access token request, despite `application/json` being mandatory. During the response parsing in flask-oauthlib we therefore cannot identify the correct datatypes of the response params, as they're all string.

* With the normal JSON type we can easily identify `expires_in` as an int. To continue this behaviour, I added a simple check to convert a string `expires_in` to an int. Without this, an error would be thrown during authentication with these implementations.

* For GitHub specifically, including `Accept: application/json` in the request headers also fixes this (the server returns a correct JSON as expected) but this is not mandatory for clients and is therefore quite difficult to do via Flask OAuthlib.