### PR TITLE
feat: add oidc provider

### DIFF
--- a/invenio_oauthclient/contrib/oidc.py
+++ b/invenio_oauthclient/contrib/oidc.py
@@ -139,7 +139,7 @@ import os
 from urllib.parse import urlparse
 
 import requests
-from flask import current_app, redirect, url_for
+from flask import current_app, redirect, session, url_for
 from flask_login import current_user
 from invenio_db import db
 from invenio_i18n import lazy_gettext as _
@@ -826,6 +826,9 @@ def account_setup(remote, token, resp):
             id_token = resp.get("id_token") if resp else None
             if id_token:
                 extra_data["id_token"] = id_token
+                # Also keep in the session so post_logout() can use it after
+                # logout_user() has cleared the user identity (but not the session).
+                session["OAUTHCLIENT_OIDC_ID_TOKEN"] = id_token
 
             token.remote_account.extra_data = extra_data
 

--- a/invenio_oauthclient/contrib/oidc.py
+++ b/invenio_oauthclient/contrib/oidc.py
@@ -1,0 +1,870 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025-2026 Front Matter.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Pre-configured remote application for enabling sign in/up with OIDC providers.
+
+This is a generic OpenID Connect (OIDC) implementation that works with any
+OIDC-compliant identity provider such as Authentik, Keycloak, Auth0, Okta, etc.
+
+1. Edit your configuration and add:
+
+   .. code-block:: python
+
+        from invenio_oauthclient.contrib import oidc
+
+        OAUTHCLIENT_REMOTE_APPS = dict(
+            oidc=oidc.REMOTE_APP,
+        )
+
+        OIDC_APP_CREDENTIALS = dict(
+            consumer_key='changeme',
+            consumer_secret='changeme',
+        )
+
+2. Register a new OAuth2/OpenID Provider application in your OIDC provider.
+   When registering the application ensure that the *Redirect URIs* includes:
+   ``http://localhost:5000/oauth/authorized/oidc/``
+
+   For production deployments:
+   ``https://yourdomain.com/oauth/authorized/oidc/``
+
+3. Configure the application in your OIDC provider:
+   - Provider type: OAuth2/OpenID Provider
+   - Client type: Confidential
+   - Authorization grant type: Authorization Code
+   - Redirect URIs: Add your callback URL
+   - Scopes: openid profile email
+
+4. Grab the *Client ID* and *Client Secret* after registering the application
+   and add them to your instance configuration (``invenio.cfg``):
+
+   .. code-block:: python
+
+        OIDC_APP_CREDENTIALS = dict(
+            consumer_key='<CLIENT ID>',
+            consumer_secret='<CLIENT SECRET>',
+        )
+
+5. Configure the OIDC provider issuer in your configuration:
+
+   .. code-block:: python
+
+        OIDC_ISSUER = 'https://your-oidc-provider.com'
+
+   For Keycloak with realms:
+
+   .. code-block:: python
+
+        OIDC_ISSUER = 'https://keycloak.example.com/realms/master'
+
+   Alternatively, you can set it via environment variable:
+
+   .. code-block:: bash
+
+        export OIDC_ISSUER='https://your-oidc-provider.com'
+
+   When using the module-level REMOTE_APP constants, the issuer is retrieved
+   from OIDC_ISSUER configuration in the following order:
+   1. Flask app config (current_app.config['OIDC_ISSUER'])
+   2. Environment variable (OIDC_ISSUER)
+
+   Note: When instantiating OIDCSettingsHelper directly, you must
+   provide issuer as a required parameter - no default value is assumed.
+
+   The module automatically discovers OAuth/OIDC endpoints using the
+   OpenID Connect Discovery specification (RFC 8414). Per OIDC spec,
+   the discovery document is located at {issuer}/.well-known/openid-configuration.
+   If discovery fails, you must provide endpoints manually.
+
+6. Now go to your site: http://localhost:5000/oauth/login/oidc/
+
+7. You should see your OIDC provider listed under Linked accounts:
+   http://localhost:5000/account/settings/linkedaccounts/
+
+If you want to customize the OAuth provider or instantiate it directly,
+you must provide the issuer parameter (required, no default):
+
+.. code-block:: python
+
+        from invenio_oauthclient.contrib import oidc
+
+        # Simple issuer
+        _my_app = oidc.OIDCSettingsHelper(
+            issuer="https://your-oidc-provider.com",  # Required parameter
+            title="My OIDC Provider",  # Optional
+            description="Custom description",  # Optional
+            use_discovery=True  # Optional, enable OIDC discovery (default: True)
+        )
+
+        # Keycloak with realm
+        _keycloak_app = oidc.OIDCSettingsHelper(
+            issuer="https://keycloak.example.com/realms/master",
+            title="Keycloak",
+        )
+
+        # Authentik with application
+        _authentik_app = oidc.OIDCSettingsHelper(
+            issuer="https://auth.example.com/application/o/myapp",
+            title="Authentik",
+        )
+
+        OAUTHCLIENT_REMOTE_APPS = dict(
+            oidc=_my_app.remote_app,
+        )
+
+        OIDC_APP_CREDENTIALS = dict(
+            consumer_key='changeme',
+            consumer_secret='changeme',
+        )
+
+The module supports OpenID Connect Discovery (RFC 8414) to automatically
+configure OAuth/OIDC endpoints. Set ``use_discovery=False`` to manually
+specify endpoints or if your OIDC provider instance doesn't expose the discovery
+endpoint.
+"""
+
+import os
+from urllib.parse import urlparse
+
+import requests
+from flask import current_app, redirect, url_for
+from flask_login import current_user
+from invenio_db import db
+from invenio_i18n import lazy_gettext as _
+from werkzeug.local import LocalProxy
+
+from invenio_oauthclient import current_oauthclient
+from invenio_oauthclient.contrib.settings import OAuthSettingsHelper
+from invenio_oauthclient.errors import OAuthResponseError
+from invenio_oauthclient.handlers.rest import response_handler
+from invenio_oauthclient.handlers.utils import require_more_than_one_external_account
+from invenio_oauthclient.models import RemoteAccount
+from invenio_oauthclient.oauth import oauth_link_external_id, oauth_unlink_external_id
+
+# Cache for OIDC discovery documents to avoid repeated network requests
+_discovery_cache = {}
+
+# Cache for JWKS (JSON Web Key Set) documents
+_jwks_cache = {}
+
+
+class OIDCSettingsHelper(OAuthSettingsHelper):
+    """Default configuration for OIDC OAuth provider."""
+
+    def __init__(
+        self,
+        title=None,
+        description=None,
+        issuer=None,
+        app_key=None,
+        icon=None,
+        access_token_url=None,
+        authorize_url=None,
+        logout_url=None,
+        precedence_mask=None,
+        signup_options=None,
+        use_discovery=True,
+        scope="openid profile email",
+    ):
+        """Constructor.
+
+        :param title: Title of the OAuth provider.
+        :param description: Description of the OAuth provider.
+        :param issuer: The issuer identifier URL (required).
+                      Per OIDC spec, this is the authorization server identifier.
+                      Examples: 'https://auth.example.com' or 'https://auth.example.com/realms/myrealm'
+                      Discovery URL is {issuer}/.well-known/openid-configuration.
+        :param app_key: Flask config key for OAuth credentials.
+        :param icon: Icon name for the provider (e.g., 'openid', 'discord').
+        :param access_token_url: OAuth token endpoint URL (auto-configured via discovery if not provided).
+        :param authorize_url: OAuth authorization endpoint URL (auto-configured via discovery if not provided).
+        :param logout_url: Logout endpoint URL (auto-configured via discovery if not provided).
+        :param precedence_mask: Dict specifying which user info fields take precedence.
+        :param signup_options: Dict with signup configuration options.
+        :param use_discovery: Whether to use OIDC discovery (RFC 8414) to
+                      auto-configure endpoints. Defaults to True.
+        :param scope: OAuth scope to request. Defaults to "openid profile email".
+        """
+        if not issuer:
+            raise ValueError("issuer is required for OIDC OAuth configuration")
+
+        # Store issuer and extract base_url for OAuth parent class
+        self.issuer = issuer
+
+        # Set default title and icon based on popular OIDC issuers
+        if issuer == "https://discord.com":
+            title = title or "Discord"
+            icon = icon or "discord"
+        elif issuer == "https://github.com/login/oauth":
+            title = title or "GitHub"
+            icon = icon or "github"
+        elif issuer == "https://gitlab.com":
+            title = title or "Gitlab"
+            icon = icon or "gitlab"
+        elif issuer == "https://accounts.google.com":
+            title = title or "Google"
+            icon = icon or "google"
+        elif issuer == "https://orcid.org/":
+            title = title or "ORCID"
+            icon = icon or "orcid"
+            signup_options = signup_options or {
+                "auto_confirm": False,
+                "send_register_msg": True,
+            }
+        elif issuer == "https://slack.com":
+            title = title or "Slack"
+            icon = icon or "slack"
+
+        # issuers used by Invenio instances
+        elif issuer == "https://auth.front-matter.de/realms/main":
+            title = title or "Front Matter"
+            icon = icon or "plug"
+            signup_options = signup_options or {"auto_confirm": True}
+
+        # Extract base_url from issuer (scheme + netloc)
+        parsed = urlparse(self.issuer)
+        base_url = f"{parsed.scheme}://{parsed.netloc}"
+
+        # Try OIDC discovery if enabled
+        self._discovery_doc = None
+        if use_discovery:
+            try:
+                self._discovery_doc = self._fetch_oidc_discovery(self.issuer)
+                if self._discovery_doc:
+                    # Explicit URLs take precedence, use discovered values as fallback
+                    access_token_url = access_token_url or self._discovery_doc.get(
+                        "token_endpoint"
+                    )
+                    authorize_url = authorize_url or self._discovery_doc.get(
+                        "authorization_endpoint"
+                    )
+                    logout_url = logout_url or self._discovery_doc.get(
+                        "end_session_endpoint"
+                    )
+
+                    # Extract supported scopes from discovery and merge with requested scopes
+                    # if available.
+                    if "scopes_supported" in self._discovery_doc:
+                        supported_scopes = set(self._discovery_doc["scopes_supported"])
+                        requested_scopes = set(scope.split())
+
+                        # Use only requested scopes that are actually supported
+                        available_scopes = requested_scopes.intersection(
+                            supported_scopes
+                        )
+
+                        # Always include openid as it's required for OIDC
+                        available_scopes.add("openid")
+
+                        # Update scope to only include supported scopes
+                        scope = " ".join(sorted(available_scopes))
+            except Exception as e:
+                # Log warning but continue with manual configuration
+                try:
+                    current_app.logger.warning(
+                        f"OIDC discovery failed for {self.issuer}: {str(e)}. "
+                        f"Using manual endpoint configuration."
+                    )
+                except RuntimeError:
+                    # No app context available, silently continue
+                    pass
+
+        # Use standard OIDC paths as fallback if discovery failed or disabled
+        # and no explicit URLs were provided
+        if not access_token_url or not authorize_url or not logout_url:
+            # Special handling for Authentik-style paths: /application/o/{app}/
+            # For these, endpoints should be at /application/o/ (without the app name)
+            endpoint_base = self._get_endpoint_base(self.issuer)
+
+            # Most OIDC providers follow the standard paths, but some providers
+            # may have different structures. Configure endpoints manually if needed.
+            access_token_url = access_token_url or f"{endpoint_base}/token"
+            authorize_url = authorize_url or f"{endpoint_base}/authorize"
+            logout_url = logout_url or f"{endpoint_base}/logout"
+
+        precedence_mask = precedence_mask or {
+            "email": True,
+            "profile": {
+                "username": True,
+                "full_name": True,
+            },
+        }
+
+        signup_options = signup_options or {
+            "auto_confirm": False,
+            "send_register_msg": False,
+        }
+
+        super().__init__(
+            title or _("OpenID Connect (OIDC)"),
+            description
+            or _(
+                "OpenID Connect allows third-party applications to verify the identity of the end-user and to obtain basic user profile information."
+            ),
+            base_url=base_url,
+            app_key=app_key or "OIDC_APP_CREDENTIALS",
+            icon=icon or "openid",
+            request_token_params={"scope": scope},
+            access_token_url=access_token_url,
+            authorize_url=authorize_url,
+            logout_url=logout_url,
+            content_type="application/json",
+            precedence_mask=precedence_mask,
+            signup_options=signup_options,
+        )
+
+        self._handlers = dict(
+            authorized_handler="invenio_oauthclient.handlers:authorized_signup_handler",
+            disconnect_handler="invenio_oauthclient.contrib.oidc:disconnect_handler",
+            signup_handler=dict(
+                info="invenio_oauthclient.contrib.oidc:account_info",
+                info_serializer="invenio_oauthclient.contrib.oidc:account_info_serializer",
+                setup="invenio_oauthclient.contrib.oidc:account_setup",
+                view="invenio_oauthclient.handlers:signup_handler",
+            ),
+        )
+
+        self._rest_handlers = dict(
+            authorized_handler="invenio_oauthclient.handlers.rest:authorized_signup_handler",
+            disconnect_handler="invenio_oauthclient.contrib.oidc:disconnect_rest_handler",
+            signup_handler=dict(
+                info="invenio_oauthclient.contrib.oidc:account_info",
+                info_serializer="invenio_oauthclient.contrib.oidc:account_info_serializer",
+                setup="invenio_oauthclient.contrib.oidc:account_setup",
+                view="invenio_oauthclient.handlers.rest:signup_handler",
+            ),
+            response_handler="invenio_oauthclient.handlers.rest:default_remote_response_handler",
+            authorized_redirect_url="/",
+            disconnect_redirect_url="/",
+            signup_redirect_url="/",
+            error_redirect_url="/",
+        )
+
+    def get_handlers(self):
+        """Return OIDC auth handlers."""
+        return self._handlers
+
+    def get_rest_handlers(self):
+        """Return OIDC auth REST handlers."""
+        return self._rest_handlers
+
+    @property
+    def userinfo_url(self):
+        """Return the URL to fetch user info from OIDC discovery or fallback."""
+        # Try to get from cached discovery document first
+        if self._discovery_doc and "userinfo_endpoint" in self._discovery_doc:
+            return self._discovery_doc["userinfo_endpoint"]
+
+        # Fallback to manual construction
+        endpoint_base = self._get_endpoint_base(self.issuer)
+        return f"{endpoint_base.rstrip('/')}/userinfo"
+
+    @property
+    def discovery_url(self):
+        """Return the OIDC discovery URL per RFC 8414.
+
+        Per OIDC spec, the discovery URL is constructed as:
+        {issuer}/.well-known/openid-configuration
+        """
+        return f"{self.issuer.rstrip('/')}/.well-known/openid-configuration"
+
+    @property
+    def jwks_url(self):
+        """Return the JWKS (JSON Web Key Set) URL from OIDC discovery or fallback.
+
+        Returns the jwks_uri from the discovery document if available,
+        otherwise falls back to the standard OIDC path.
+        """
+        # Try to get from cached discovery document first
+        if self._discovery_doc and "jwks_uri" in self._discovery_doc:
+            return self._discovery_doc["jwks_uri"]
+
+        # Fallback to manual construction
+        return f"{self.issuer.rstrip('/')}/jwks"
+
+    @property
+    def logout_url(self):
+        """Return the logout URL from OIDC discovery or fallback.
+
+        Uses the full issuer path, including application name for Authentik.
+        """
+        # Try to get from cached discovery document first
+        if self._discovery_doc and "end_session_endpoint" in self._discovery_doc:
+            return self._discovery_doc["end_session_endpoint"]
+
+        # Fallback to manual construction
+        return f"{self.issuer.rstrip('/')}/logout"
+
+    @staticmethod
+    def _get_endpoint_base(issuer):
+        """Get the endpoint base URL from issuer.
+
+        For Authentik-style paths (/application/o/{app}/), returns the base path
+        without the app name. For other issuers, returns the issuer unchanged.
+
+        :param issuer: The issuer identifier.
+        :returns: The endpoint base URL.
+        """
+        if "/application/o/" in issuer:
+            parts = issuer.split("/application/o/")
+            if len(parts) == 2:
+                return f"{parts[0]}/application/o"
+        return issuer
+
+    @staticmethod
+    def _fetch_oidc_discovery(issuer):
+        """Fetch and cache OIDC discovery document.
+
+        Implements OpenID Connect Discovery 1.0 (RFC 8414) for automatic
+        endpoint configuration.
+
+        Per OIDC spec, the discovery document is located at:
+        {issuer}/.well-known/openid-configuration
+
+        :param issuer: The issuer identifier (base_url + optional path).
+        :returns: Dictionary containing the discovery document or None.
+        """
+        # Check cache first to avoid repeated network requests
+        if issuer in _discovery_cache:
+            return _discovery_cache[issuer]
+
+        # Construct discovery URL per OIDC spec
+        discovery_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+
+        try:
+            response = requests.get(discovery_url, timeout=10)
+            response.raise_for_status()
+            discovery_doc = response.json()
+
+            # Validate required OIDC discovery fields per RFC 8414
+            required_fields = [
+                "issuer",
+                "authorization_endpoint",
+                "token_endpoint",
+                "userinfo_endpoint",
+            ]
+
+            if not all(field in discovery_doc for field in required_fields):
+                raise ValueError(
+                    f"Discovery document missing required fields: {required_fields}"
+                )
+
+            # Cache the discovery document using the issuer as key
+            _discovery_cache[issuer] = discovery_doc
+            return discovery_doc
+
+        except (requests.RequestException, ValueError):
+            # Return None to trigger fallback to manual configuration
+            return None
+
+    @staticmethod
+    def _fetch_jwks(jwks_uri):
+        """Fetch and cache JWKS (JSON Web Key Set) document.
+
+        JWKS contains the public keys used to verify JWT signatures.
+        This is essential for validating ID tokens in OIDC flows.
+
+        :param jwks_uri: The URI of the JWKS endpoint.
+        :returns: Dictionary containing the JWKS document or None.
+        """
+        # Check cache first to avoid repeated network requests
+        if jwks_uri in _jwks_cache:
+            return _jwks_cache[jwks_uri]
+
+        try:
+            response = requests.get(jwks_uri, timeout=10)
+            response.raise_for_status()
+            jwks_doc = response.json()
+
+            # Validate JWKS structure - must contain 'keys' array
+            if "keys" not in jwks_doc or not isinstance(jwks_doc["keys"], list):
+                raise ValueError("JWKS document must contain 'keys' array")
+
+            # Cache the JWKS document
+            _jwks_cache[jwks_uri] = jwks_doc
+            return jwks_doc
+
+        except (requests.RequestException, ValueError) as e:
+            try:
+                current_app.logger.warning(
+                    f"Failed to fetch JWKS from {jwks_uri}: {str(e)}"
+                )
+            except RuntimeError:
+                # No app context available
+                pass
+            return None
+
+    def get_jwks(self):
+        """Get the JWKS (JSON Web Key Set) for this OIDC provider.
+
+        Returns the cached JWKS or fetches it from the jwks_uri.
+
+        :returns: Dictionary containing the JWKS document or None if unavailable.
+        """
+        jwks_uri = self.jwks_url
+        if jwks_uri:
+            return self._fetch_jwks(jwks_uri)
+        return None
+
+
+def _get_oidc_app():
+    """Get or create OIDC app instance with runtime configuration.
+
+    This function allows for lazy initialization to access current_app.config
+    at runtime instead of module import time. It checks for OIDC_ISSUER
+    in the following order:
+    1. Flask app config (current_app.config)
+    2. Environment variable (OIDC_ISSUER)
+    3. Returns None if not configured (OIDC disabled)
+    """
+    try:
+        issuer = current_app.config.get(
+            "OIDC_ISSUER",
+            os.environ.get("OIDC_ISSUER", None),
+        )
+    except RuntimeError:
+        # No app context available, use environment variable
+        issuer = os.environ.get("OIDC_ISSUER", None)
+
+    if not issuer:
+        # OIDC not configured, return None to disable
+        return None
+
+    return OIDCSettingsHelper(issuer=issuer)
+
+
+# Module-level helper functions for lazy-loaded configuration
+def _get_base_app():
+    """Get BASE_APP configuration with runtime config access."""
+    app = _get_oidc_app()
+    return app.base_app if app else None
+
+
+def _get_remote_app():
+    """Get REMOTE_APP configuration with runtime config access."""
+    app = _get_oidc_app()
+    return app.remote_app if app else None
+
+
+def _get_remote_rest_app():
+    """Get REMOTE_REST_APP configuration with runtime config access."""
+    app = _get_oidc_app()
+    return app.remote_rest_app if app else None
+
+
+# Module-level lazy-loaded configuration using LocalProxy
+# These proxies delay evaluation until accessed within an app context
+BASE_APP = LocalProxy(_get_base_app)
+"""OIDC base application configuration (lazy-loaded)."""
+
+REMOTE_APP = LocalProxy(_get_remote_app)
+"""OIDC remote application configuration (lazy-loaded)."""
+
+REMOTE_REST_APP = LocalProxy(_get_remote_rest_app)
+"""OIDC remote REST application configuration (lazy-loaded)."""
+
+
+def get_user_info(remote):
+    """Get user information from OIDC userinfo endpoint.
+
+    Follows the OpenID Connect Core 1.0 specification for the userinfo endpoint.
+
+    :param remote: The remote application.
+    :returns: User information dictionary.
+    :raises OAuthResponseError: If the request fails or response is invalid.
+    """
+    try:
+        # Get issuer and construct OIDCSettingsHelper to access userinfo_url
+        # which uses OIDC discovery when available
+        app = _get_oidc_app()
+        issuer = getattr(remote, "issuer", app.issuer)
+        helper = OIDCSettingsHelper(issuer=issuer)
+        response = remote.get(helper.userinfo_url)
+        if getattr(response, "_resp", None) and response._resp.code >= 400:
+            raise OAuthResponseError(
+                _("Failed to fetch user information from OIDC provider"),
+                None,
+                response,
+            )
+
+        user_info = response.data
+
+        # Validate required OIDC fields
+        if "sub" not in user_info:
+            raise OAuthResponseError(
+                _("Missing subject identifier in user info"),
+                None,
+                response,
+            )
+
+        return user_info
+
+    except Exception as e:
+        if isinstance(e, OAuthResponseError):
+            raise
+        raise OAuthResponseError(
+            _("Failed to fetch user information"), None, None
+        ) from e
+
+
+def _normalize_orcid(orcid):
+    """Normalize an ORCID iD value.
+
+    If the value is given as a URL (e.g. 'https://orcid.org/<id>'), it returns
+    the bare ORCID iD.
+    """
+    if not orcid:
+        return None
+
+    if not isinstance(orcid, str):
+        return orcid
+
+    value = orcid.strip()
+    for prefix in (
+        "https://orcid.org/",
+        "http://orcid.org/",
+    ):
+        if value.startswith(prefix):
+            value = value[len(prefix) :]
+            break
+
+    value = value.lstrip("/").rstrip("/")
+    return value or None
+
+
+def account_info_serializer(remote, resp, user_info=None, **kwargs):
+    """Serialize the account info response object.
+
+    :param remote: The remote application.
+    :param resp: The response of the `authorized` endpoint.
+    :param user_info: User info from userinfo endpoint.
+    :returns: A dictionary with serialized user information.
+    """
+    if not user_info:
+        raise ValueError("User info is required for account serialization")
+
+    # Extract external ID from 'sub' claim (standard OIDC)
+    external_id = user_info.get("sub")
+    if not external_id:
+        raise ValueError("Subject identifier (sub) is required")
+
+    # Extract email with fallback
+    email = user_info.get("email")
+    if not email:
+        current_app.logger.warning(
+            "No email provided by OIDC provider, using sub as fallback"
+        )
+        email = f"{external_id}@oidc.local"
+
+    # Extract username with fallbacks
+    username = (
+        user_info.get("preferred_username")
+        or user_info.get("nickname")
+        or user_info.get("sub")
+    )
+
+    # Extract full name with fallback
+    full_name = user_info.get("name", "")
+    if not full_name and user_info.get("given_name"):
+        full_name = " ".join(
+            filter(
+                None,
+                [user_info.get("given_name"), user_info.get("family_name")],
+            )
+        )
+
+    # Optional ORCID (if provided by the OIDC provider)
+    orcid = _normalize_orcid(user_info.get("orcid"))
+
+    # Optional picture (if provided by the OIDC provider)
+    picture = user_info.get("picture")
+    if isinstance(picture, str):
+        picture = picture.strip() or None
+
+    profile = {
+        "username": username,
+        "full_name": full_name,
+    }
+    if orcid:
+        profile["orcid"] = orcid
+    if picture:
+        profile["picture"] = picture
+
+    return {
+        "external_id": external_id,
+        "external_method": remote.name,
+        "user": {
+            "email": email,
+            "profile": {
+                **profile,
+            },
+        },
+    }
+
+
+def account_info(remote, resp):
+    """Retrieve remote account information used to find local user.
+
+    It returns a dictionary with the following structure:
+
+    .. code-block:: python
+
+        {
+            'user': {
+                'email': '...',
+                'profile': {
+                    'username': '...',
+                    'full_name': '...',
+                    # Optional: picture URL if provided by the OIDC provider
+                    'picture': 'https://example.org/avatar.jpg',
+                    # Optional: ORCID iD if provided by the OIDC provider
+                    'orcid': '0000-0002-1825-0097',
+                },
+            },
+            'external_id': 'oidc-sub-claim',
+            'external_method': 'oidc',
+        }
+
+    :param remote: The remote application.
+    :param resp: The response of the `authorized` endpoint.
+    :returns: A dictionary with the user information.
+    """
+    try:
+        user_info = get_user_info(remote)
+        handlers = current_oauthclient.signup_handlers[remote.name]
+        # `remote` param automatically injected via `make_handler` helper
+        return handlers["info_serializer"](resp, user_info=user_info)
+
+    except Exception as e:
+        current_app.logger.error(f"Failed to get account info: {str(e)}")
+        raise
+
+
+def account_setup(remote, token, resp):
+    """Perform additional setup after user has been logged in.
+
+    :param remote: The remote application.
+    :param token: The token value.
+    :param resp: The response.
+    """
+    try:
+        user_info = get_user_info(remote)
+        current_app.logger.debug(f"User info retrieved: {user_info}")
+
+        with db.session.begin_nested():
+            # Store comprehensive user data in extra_data
+            extra_data = {
+                "sub": user_info.get("sub"),
+                "email": user_info.get("email"),
+                "full_name": user_info.get("name", ""),
+                "username": (
+                    user_info.get("preferred_username")
+                    or user_info.get("nickname")
+                    or ""
+                ),
+            }
+
+            # Store optional fields if present
+            optional_fields = [
+                "given_name",
+                "family_name",
+                "nickname",
+                "preferred_username",
+                "groups",
+                "picture",
+            ]
+            for field in optional_fields:
+                if field in user_info:
+                    extra_data[field] = user_info[field]
+
+            # Optional ORCID (if provided by the OIDC provider)
+            orcid = _normalize_orcid(user_info.get("orcid"))
+            if orcid:
+                extra_data["orcid"] = orcid
+
+            token.remote_account.extra_data = extra_data
+
+            # Create user <-> external id link using 'sub' claim
+            external_id = user_info.get("sub")
+            if external_id:
+                oauth_link_external_id(
+                    token.remote_account.user,
+                    dict(id=external_id, method=remote.name),
+                )
+
+            # Create user <-> external id link using optional ORCID iD.
+            if orcid:
+                oauth_link_external_id(
+                    token.remote_account.user,
+                    dict(id=orcid, method="orcid"),
+                )
+
+    except Exception as e:
+        current_app.logger.error(f"Account setup failed: {str(e)}")
+        db.session.rollback()
+        raise
+
+
+@require_more_than_one_external_account
+def _disconnect(remote, *args, **kwargs):
+    """Handle unlinking of remote account.
+
+    :param remote: The remote application.
+    """
+    if not current_user.is_authenticated:
+        return current_app.login_manager.unauthorized()
+
+    account = RemoteAccount.get(
+        user_id=current_user.get_id(), client_id=remote.consumer_key
+    )
+
+    # Remove external ID links
+    external_ids = [
+        i.id for i in current_user.external_identifiers if i.method == remote.name
+    ]
+    for external_id in external_ids:
+        oauth_unlink_external_id(dict(id=external_id, method=remote.name))
+
+    # Remove optional ORCID external ID link (if it was linked by this remote).
+    if account and isinstance(account.extra_data, dict):
+        orcid = account.extra_data.get("orcid")
+        if orcid:
+            orcid_ids = [
+                i.id
+                for i in current_user.external_identifiers
+                if i.method == "orcid" and i.id == orcid
+            ]
+            for orcid_id in orcid_ids:
+                oauth_unlink_external_id(dict(id=orcid_id, method="orcid"))
+
+    if account:
+        with db.session.begin_nested():
+            account.delete()
+
+
+def disconnect_handler(remote, *args, **kwargs):
+    """Handle unlinking of remote account.
+
+    :param remote: The remote application.
+    :returns: The HTML response.
+    """
+    _disconnect(remote, *args, **kwargs)
+    return redirect(url_for("invenio_oauthclient_settings.index"))
+
+
+def disconnect_rest_handler(remote, *args, **kwargs):
+    """Handle unlinking of remote account.
+
+    :param remote: The remote application.
+    :returns: The JSON response.
+    """
+    _disconnect(remote, *args, **kwargs)
+    redirect_url = current_app.config["OAUTHCLIENT_REST_REMOTE_APPS"][remote.name][
+        "disconnect_redirect_url"
+    ]
+    return response_handler(remote, redirect_url)

--- a/invenio_oauthclient/contrib/oidc.py
+++ b/invenio_oauthclient/contrib/oidc.py
@@ -1,0 +1,895 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025-2026 Front Matter.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Pre-configured remote application for enabling sign in/up with OIDC providers.
+
+This is a generic OpenID Connect (OIDC) implementation that works with any
+OIDC-compliant identity provider such as Authentik, Keycloak, Auth0, Okta, etc.
+
+1. Edit your configuration and add:
+
+   .. code-block:: python
+
+        from invenio_oauthclient.contrib import oidc
+
+        OAUTHCLIENT_REMOTE_APPS = dict(
+            oidc=oidc.REMOTE_APP,
+        )
+
+        OIDC_APP_CREDENTIALS = dict(
+            consumer_key='changeme',
+            consumer_secret='changeme',
+        )
+
+2. Register a new OAuth2/OpenID Provider application in your OIDC provider.
+   When registering the application ensure that the *Redirect URIs* includes:
+   ``http://localhost:5000/oauth/authorized/oidc/``
+
+   For production deployments:
+   ``https://yourdomain.com/oauth/authorized/oidc/``
+
+3. Configure the application in your OIDC provider:
+   - Provider type: OAuth2/OpenID Provider
+   - Client type: Confidential
+   - Authorization grant type: Authorization Code
+   - Redirect URIs: Add your callback URL
+   - Scopes: openid profile email
+
+4. Grab the *Client ID* and *Client Secret* after registering the application
+   and add them to your instance configuration (``invenio.cfg``):
+
+   .. code-block:: python
+
+        OIDC_APP_CREDENTIALS = dict(
+            consumer_key='<CLIENT ID>',
+            consumer_secret='<CLIENT SECRET>',
+        )
+
+5. Configure the OIDC provider issuer in your configuration:
+
+   .. code-block:: python
+
+        OIDC_ISSUER = 'https://your-oidc-provider.com'
+
+   Some OIDC providers require HTTP Basic Authentication for the token endpoint
+   instead of sending credentials in the POST body. Enable it with:
+
+   .. code-block:: python
+
+        OIDC_USE_BASIC_AUTH = True
+
+   For Keycloak with realms:
+
+   .. code-block:: python
+
+        OIDC_ISSUER = 'https://keycloak.example.com/realms/master'
+
+   Alternatively, you can set it via environment variable:
+
+   .. code-block:: bash
+
+        export OIDC_ISSUER='https://your-oidc-provider.com'
+
+   When using the module-level REMOTE_APP constants, the issuer is retrieved
+   from OIDC_ISSUER configuration in the following order:
+   1. Flask app config (current_app.config['OIDC_ISSUER'])
+   2. Environment variable (OIDC_ISSUER)
+
+   Note: When instantiating OIDCSettingsHelper directly, you must
+   provide issuer as a required parameter - no default value is assumed.
+
+   The module automatically discovers OAuth/OIDC endpoints using the
+   OpenID Connect Discovery specification (RFC 8414). Per OIDC spec,
+   the discovery document is located at {issuer}/.well-known/openid-configuration.
+   If discovery fails, you must provide endpoints manually.
+
+6. Now go to your site: http://localhost:5000/oauth/login/oidc/
+
+7. You should see your OIDC provider listed under Linked accounts:
+   http://localhost:5000/account/settings/linkedaccounts/
+
+If you want to customize the OAuth provider or instantiate it directly,
+you must provide the issuer parameter (required, no default):
+
+.. code-block:: python
+
+        from invenio_oauthclient.contrib import oidc
+
+        # Simple issuer
+        _my_app = oidc.OIDCSettingsHelper(
+            issuer="https://your-oidc-provider.com",  # Required parameter
+            title="My OIDC Provider",  # Optional
+            description="Custom description",  # Optional
+            use_discovery=True  # Optional, enable OIDC discovery (default: True)
+        )
+
+        # Keycloak with realm
+        _keycloak_app = oidc.OIDCSettingsHelper(
+            issuer="https://keycloak.example.com/realms/master",
+            title="Keycloak",
+        )
+
+        # Authentik with application
+        _authentik_app = oidc.OIDCSettingsHelper(
+            issuer="https://auth.example.com/application/o/myapp",
+            title="Authentik",
+        )
+
+        OAUTHCLIENT_REMOTE_APPS = dict(
+            oidc=_my_app.remote_app,
+        )
+
+        OIDC_APP_CREDENTIALS = dict(
+            consumer_key='changeme',
+            consumer_secret='changeme',
+        )
+
+The module supports OpenID Connect Discovery (RFC 8414) to automatically
+configure OAuth/OIDC endpoints. Set ``use_discovery=False`` to manually
+specify endpoints or if your OIDC provider instance doesn't expose the discovery
+endpoint.
+"""
+
+import os
+from urllib.parse import urlparse
+
+import requests
+from flask import current_app, redirect, url_for
+from flask_login import current_user
+from invenio_db import db
+from invenio_i18n import lazy_gettext as _
+from werkzeug.local import LocalProxy
+
+from invenio_oauthclient import current_oauthclient
+from invenio_oauthclient.contrib.settings import OAuthSettingsHelper
+from invenio_oauthclient.errors import OAuthResponseError
+from invenio_oauthclient.handlers.rest import response_handler
+from invenio_oauthclient.handlers.utils import require_more_than_one_external_account
+from invenio_oauthclient.models import RemoteAccount
+from invenio_oauthclient.oauth import oauth_link_external_id, oauth_unlink_external_id
+
+# Cache for OIDC discovery documents to avoid repeated network requests
+_discovery_cache = {}
+
+# Cache for JWKS (JSON Web Key Set) documents
+_jwks_cache = {}
+
+
+class OIDCSettingsHelper(OAuthSettingsHelper):
+    """Default configuration for OIDC OAuth provider."""
+
+    def __init__(
+        self,
+        title=None,
+        description=None,
+        issuer=None,
+        app_key=None,
+        icon=None,
+        access_token_url=None,
+        authorize_url=None,
+        logout_url=None,
+        precedence_mask=None,
+        signup_options=None,
+        use_discovery=True,
+        use_basic_auth=False,
+        scope="openid profile email",
+    ):
+        """Constructor.
+
+        :param title: Title of the OAuth provider.
+        :param description: Description of the OAuth provider.
+        :param issuer: The issuer identifier URL (required).
+                      Per OIDC spec, this is the authorization server identifier.
+                      Examples: 'https://auth.example.com' or 'https://auth.example.com/realms/myrealm'
+                      Discovery URL is {issuer}/.well-known/openid-configuration.
+        :param app_key: Flask config key for OAuth credentials.
+        :param icon: Icon name for the provider (e.g., 'openid', 'discord').
+        :param access_token_url: OAuth token endpoint URL (auto-configured via discovery if not provided).
+        :param authorize_url: OAuth authorization endpoint URL (auto-configured via discovery if not provided).
+        :param logout_url: Logout endpoint URL (auto-configured via discovery if not provided).
+        :param precedence_mask: Dict specifying which user info fields take precedence.
+        :param signup_options: Dict with signup configuration options.
+        :param use_discovery: Whether to use OIDC discovery (RFC 8414) to
+                      auto-configure endpoints. Defaults to True.
+        :param use_basic_auth: Whether to use HTTP Basic Authentication
+                      (client_secret_basic) for the token endpoint instead of
+                      sending credentials in the request body
+                      (client_secret_post). Some OIDC providers require this.
+                      Defaults to False.
+        :param scope: OAuth scope to request. Defaults to "openid profile email".
+        """
+        if not issuer:
+            raise ValueError("issuer is required for OIDC OAuth configuration")
+
+        # Store issuer and extract base_url for OAuth parent class
+        self.issuer = issuer
+
+        # Set default title and icon based on popular OIDC issuers
+        if issuer == "https://discord.com":
+            title = title or "Discord"
+            icon = icon or "discord"
+        elif issuer == "https://github.com/login/oauth":
+            title = title or "GitHub"
+            icon = icon or "github"
+        elif issuer == "https://gitlab.com":
+            title = title or "Gitlab"
+            icon = icon or "gitlab"
+        elif issuer == "https://accounts.google.com":
+            title = title or "Google"
+            icon = icon or "google"
+        elif issuer == "https://orcid.org/":
+            title = title or "ORCID"
+            icon = icon or "orcid"
+            signup_options = signup_options or {
+                "auto_confirm": False,
+                "send_register_msg": True,
+            }
+        elif issuer == "https://slack.com":
+            title = title or "Slack"
+            icon = icon or "slack"
+
+        # issuers used by Invenio instances
+        elif issuer == "https://auth.front-matter.de/realms/main":
+            title = title or "Front Matter"
+            icon = icon or "plug"
+            signup_options = signup_options or {"auto_confirm": True}
+
+        # Extract base_url from issuer (scheme + netloc)
+        parsed = urlparse(self.issuer)
+        base_url = f"{parsed.scheme}://{parsed.netloc}"
+
+        # Try OIDC discovery if enabled
+        self._discovery_doc = None
+        if use_discovery:
+            try:
+                self._discovery_doc = self._fetch_oidc_discovery(self.issuer)
+                if self._discovery_doc:
+                    # Explicit URLs take precedence, use discovered values as fallback
+                    access_token_url = access_token_url or self._discovery_doc.get(
+                        "token_endpoint"
+                    )
+                    authorize_url = authorize_url or self._discovery_doc.get(
+                        "authorization_endpoint"
+                    )
+                    logout_url = logout_url or self._discovery_doc.get(
+                        "end_session_endpoint"
+                    )
+
+                    # Extract supported scopes from discovery and merge with requested scopes
+                    # if available.
+                    if "scopes_supported" in self._discovery_doc:
+                        supported_scopes = set(self._discovery_doc["scopes_supported"])
+                        requested_scopes = set(scope.split())
+
+                        # Use only requested scopes that are actually supported
+                        available_scopes = requested_scopes.intersection(
+                            supported_scopes
+                        )
+
+                        # Always include openid as it's required for OIDC
+                        available_scopes.add("openid")
+
+                        # Update scope to only include supported scopes
+                        scope = " ".join(sorted(available_scopes))
+            except Exception as e:
+                # Log warning but continue with manual configuration
+                try:
+                    current_app.logger.warning(
+                        f"OIDC discovery failed for {self.issuer}: {str(e)}. "
+                        f"Using manual endpoint configuration."
+                    )
+                except RuntimeError:
+                    # No app context available, silently continue
+                    pass
+
+        # Use standard OIDC paths as fallback if discovery failed or disabled
+        # and no explicit URLs were provided
+        if not access_token_url or not authorize_url or not logout_url:
+            # Special handling for Authentik-style paths: /application/o/{app}/
+            # For these, endpoints should be at /application/o/ (without the app name)
+            endpoint_base = self._get_endpoint_base(self.issuer)
+
+            # Most OIDC providers follow the standard paths, but some providers
+            # may have different structures. Configure endpoints manually if needed.
+            access_token_url = access_token_url or f"{endpoint_base}/token"
+            authorize_url = authorize_url or f"{endpoint_base}/authorize"
+            logout_url = logout_url or f"{endpoint_base}/logout"
+
+        precedence_mask = precedence_mask or {
+            "email": True,
+            "profile": {
+                "username": True,
+                "full_name": True,
+            },
+        }
+
+        signup_options = signup_options or {
+            "auto_confirm": False,
+            "send_register_msg": False,
+        }
+
+        # Build extra kwargs for the OAuth library
+        extra_params = {}
+        if use_basic_auth:
+            # Instructs the OAuth library (Authlib) to send client credentials
+            # via the HTTP Authorization header (RFC 6749 §2.3.1) rather than
+            # in the POST body ('client_secret_post').
+            extra_params["token_endpoint_auth_method"] = "client_secret_basic"
+
+        super().__init__(
+            title or _("OpenID Connect (OIDC)"),
+            description
+            or _(
+                "OpenID Connect allows third-party applications to verify the identity of the end-user and to obtain basic user profile information."
+            ),
+            base_url=base_url,
+            app_key=app_key or "OIDC_APP_CREDENTIALS",
+            icon=icon or "openid",
+            request_token_params={"scope": scope},
+            access_token_url=access_token_url,
+            authorize_url=authorize_url,
+            logout_url=logout_url,
+            content_type="application/json",
+            precedence_mask=precedence_mask,
+            signup_options=signup_options,
+            **extra_params,
+        )
+
+        self._handlers = dict(
+            authorized_handler="invenio_oauthclient.handlers:authorized_signup_handler",
+            disconnect_handler="invenio_oauthclient.contrib.oidc:disconnect_handler",
+            signup_handler=dict(
+                info="invenio_oauthclient.contrib.oidc:account_info",
+                info_serializer="invenio_oauthclient.contrib.oidc:account_info_serializer",
+                setup="invenio_oauthclient.contrib.oidc:account_setup",
+                view="invenio_oauthclient.handlers:signup_handler",
+            ),
+        )
+
+        self._rest_handlers = dict(
+            authorized_handler="invenio_oauthclient.handlers.rest:authorized_signup_handler",
+            disconnect_handler="invenio_oauthclient.contrib.oidc:disconnect_rest_handler",
+            signup_handler=dict(
+                info="invenio_oauthclient.contrib.oidc:account_info",
+                info_serializer="invenio_oauthclient.contrib.oidc:account_info_serializer",
+                setup="invenio_oauthclient.contrib.oidc:account_setup",
+                view="invenio_oauthclient.handlers.rest:signup_handler",
+            ),
+            response_handler="invenio_oauthclient.handlers.rest:default_remote_response_handler",
+            authorized_redirect_url="/",
+            disconnect_redirect_url="/",
+            signup_redirect_url="/",
+            error_redirect_url="/",
+        )
+
+    def get_handlers(self):
+        """Return OIDC auth handlers."""
+        return self._handlers
+
+    def get_rest_handlers(self):
+        """Return OIDC auth REST handlers."""
+        return self._rest_handlers
+
+    @property
+    def userinfo_url(self):
+        """Return the URL to fetch user info from OIDC discovery or fallback."""
+        # Try to get from cached discovery document first
+        if self._discovery_doc and "userinfo_endpoint" in self._discovery_doc:
+            return self._discovery_doc["userinfo_endpoint"]
+
+        # Fallback to manual construction
+        endpoint_base = self._get_endpoint_base(self.issuer)
+        return f"{endpoint_base.rstrip('/')}/userinfo"
+
+    @property
+    def discovery_url(self):
+        """Return the OIDC discovery URL per RFC 8414.
+
+        Per OIDC spec, the discovery URL is constructed as:
+        {issuer}/.well-known/openid-configuration
+        """
+        return f"{self.issuer.rstrip('/')}/.well-known/openid-configuration"
+
+    @property
+    def jwks_url(self):
+        """Return the JWKS (JSON Web Key Set) URL from OIDC discovery or fallback.
+
+        Returns the jwks_uri from the discovery document if available,
+        otherwise falls back to the standard OIDC path.
+        """
+        # Try to get from cached discovery document first
+        if self._discovery_doc and "jwks_uri" in self._discovery_doc:
+            return self._discovery_doc["jwks_uri"]
+
+        # Fallback to manual construction
+        return f"{self.issuer.rstrip('/')}/jwks"
+
+    @property
+    def logout_url(self):
+        """Return the logout URL from OIDC discovery or fallback.
+
+        Uses the full issuer path, including application name for Authentik.
+        """
+        # Try to get from cached discovery document first
+        if self._discovery_doc and "end_session_endpoint" in self._discovery_doc:
+            return self._discovery_doc["end_session_endpoint"]
+
+        # Fallback to manual construction
+        return f"{self.issuer.rstrip('/')}/logout"
+
+    @staticmethod
+    def _get_endpoint_base(issuer):
+        """Get the endpoint base URL from issuer.
+
+        For Authentik-style paths (/application/o/{app}/), returns the base path
+        without the app name. For other issuers, returns the issuer unchanged.
+
+        :param issuer: The issuer identifier.
+        :returns: The endpoint base URL.
+        """
+        if "/application/o/" in issuer:
+            parts = issuer.split("/application/o/")
+            if len(parts) == 2:
+                return f"{parts[0]}/application/o"
+        return issuer
+
+    @staticmethod
+    def _fetch_oidc_discovery(issuer):
+        """Fetch and cache OIDC discovery document.
+
+        Implements OpenID Connect Discovery 1.0 (RFC 8414) for automatic
+        endpoint configuration.
+
+        Per OIDC spec, the discovery document is located at:
+        {issuer}/.well-known/openid-configuration
+
+        :param issuer: The issuer identifier (base_url + optional path).
+        :returns: Dictionary containing the discovery document or None.
+        """
+        # Check cache first to avoid repeated network requests
+        if issuer in _discovery_cache:
+            return _discovery_cache[issuer]
+
+        # Construct discovery URL per OIDC spec
+        discovery_url = f"{issuer.rstrip('/')}/.well-known/openid-configuration"
+
+        try:
+            response = requests.get(discovery_url, timeout=10)
+            response.raise_for_status()
+            discovery_doc = response.json()
+
+            # Validate required OIDC discovery fields per RFC 8414
+            required_fields = [
+                "issuer",
+                "authorization_endpoint",
+                "token_endpoint",
+                "userinfo_endpoint",
+            ]
+
+            if not all(field in discovery_doc for field in required_fields):
+                raise ValueError(
+                    f"Discovery document missing required fields: {required_fields}"
+                )
+
+            # Cache the discovery document using the issuer as key
+            _discovery_cache[issuer] = discovery_doc
+            return discovery_doc
+
+        except (requests.RequestException, ValueError):
+            # Return None to trigger fallback to manual configuration
+            return None
+
+    @staticmethod
+    def _fetch_jwks(jwks_uri):
+        """Fetch and cache JWKS (JSON Web Key Set) document.
+
+        JWKS contains the public keys used to verify JWT signatures.
+        This is essential for validating ID tokens in OIDC flows.
+
+        :param jwks_uri: The URI of the JWKS endpoint.
+        :returns: Dictionary containing the JWKS document or None.
+        """
+        # Check cache first to avoid repeated network requests
+        if jwks_uri in _jwks_cache:
+            return _jwks_cache[jwks_uri]
+
+        try:
+            response = requests.get(jwks_uri, timeout=10)
+            response.raise_for_status()
+            jwks_doc = response.json()
+
+            # Validate JWKS structure - must contain 'keys' array
+            if "keys" not in jwks_doc or not isinstance(jwks_doc["keys"], list):
+                raise ValueError("JWKS document must contain 'keys' array")
+
+            # Cache the JWKS document
+            _jwks_cache[jwks_uri] = jwks_doc
+            return jwks_doc
+
+        except (requests.RequestException, ValueError) as e:
+            try:
+                current_app.logger.warning(
+                    f"Failed to fetch JWKS from {jwks_uri}: {str(e)}"
+                )
+            except RuntimeError:
+                # No app context available
+                pass
+            return None
+
+    def get_jwks(self):
+        """Get the JWKS (JSON Web Key Set) for this OIDC provider.
+
+        Returns the cached JWKS or fetches it from the jwks_uri.
+
+        :returns: Dictionary containing the JWKS document or None if unavailable.
+        """
+        jwks_uri = self.jwks_url
+        if jwks_uri:
+            return self._fetch_jwks(jwks_uri)
+        return None
+
+
+def _get_oidc_app():
+    """Get or create OIDC app instance with runtime configuration.
+
+    This function allows for lazy initialization to access current_app.config
+    at runtime instead of module import time. It checks for OIDC_ISSUER
+    in the following order:
+    1. Flask app config (current_app.config)
+    2. Environment variable (OIDC_ISSUER)
+    3. Returns None if not configured (OIDC disabled)
+    """
+    try:
+        issuer = current_app.config.get(
+            "OIDC_ISSUER",
+            os.environ.get("OIDC_ISSUER", None),
+        )
+    except RuntimeError:
+        # No app context available, use environment variable
+        issuer = os.environ.get("OIDC_ISSUER", None)
+
+    if not issuer:
+        # OIDC not configured, return None to disable
+        return None
+
+    try:
+        use_basic_auth = current_app.config.get(
+            "OIDC_USE_BASIC_AUTH",
+            os.environ.get("OIDC_USE_BASIC_AUTH", "false").lower()
+            in ("1", "true", "yes"),
+        )
+    except RuntimeError:
+        use_basic_auth = os.environ.get("OIDC_USE_BASIC_AUTH", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+    return OIDCSettingsHelper(issuer=issuer, use_basic_auth=use_basic_auth)
+
+
+# Module-level helper functions for lazy-loaded configuration
+def _get_base_app():
+    """Get BASE_APP configuration with runtime config access."""
+    app = _get_oidc_app()
+    return app.base_app if app else None
+
+
+def _get_remote_app():
+    """Get REMOTE_APP configuration with runtime config access."""
+    app = _get_oidc_app()
+    return app.remote_app if app else None
+
+
+def _get_remote_rest_app():
+    """Get REMOTE_REST_APP configuration with runtime config access."""
+    app = _get_oidc_app()
+    return app.remote_rest_app if app else None
+
+
+# Module-level lazy-loaded configuration using LocalProxy
+# These proxies delay evaluation until accessed within an app context
+BASE_APP = LocalProxy(_get_base_app)
+"""OIDC base application configuration (lazy-loaded)."""
+
+REMOTE_APP = LocalProxy(_get_remote_app)
+"""OIDC remote application configuration (lazy-loaded)."""
+
+REMOTE_REST_APP = LocalProxy(_get_remote_rest_app)
+"""OIDC remote REST application configuration (lazy-loaded)."""
+
+
+def get_user_info(remote):
+    """Get user information from OIDC userinfo endpoint.
+
+    Follows the OpenID Connect Core 1.0 specification for the userinfo endpoint.
+
+    :param remote: The remote application.
+    :returns: User information dictionary.
+    :raises OAuthResponseError: If the request fails or response is invalid.
+    """
+    try:
+        # Get issuer and construct OIDCSettingsHelper to access userinfo_url
+        # which uses OIDC discovery when available
+        app = _get_oidc_app()
+        issuer = getattr(remote, "issuer", app.issuer)
+        helper = OIDCSettingsHelper(issuer=issuer)
+        response = remote.get(helper.userinfo_url)
+        if getattr(response, "_resp", None) and response._resp.code >= 400:
+            raise OAuthResponseError(
+                _("Failed to fetch user information from OIDC provider"),
+                None,
+                response,
+            )
+
+        user_info = response.data
+
+        # Validate required OIDC fields
+        if "sub" not in user_info:
+            raise OAuthResponseError(
+                _("Missing subject identifier in user info"),
+                None,
+                response,
+            )
+
+        return user_info
+
+    except Exception as e:
+        if isinstance(e, OAuthResponseError):
+            raise
+        raise OAuthResponseError(
+            _("Failed to fetch user information"), None, None
+        ) from e
+
+
+def _normalize_orcid(orcid):
+    """Normalize an ORCID iD value.
+
+    If the value is given as a URL (e.g. 'https://orcid.org/<id>'), it returns
+    the bare ORCID iD.
+    """
+    if not orcid:
+        return None
+
+    if not isinstance(orcid, str):
+        return orcid
+
+    value = orcid.strip()
+    for prefix in (
+        "https://orcid.org/",
+        "http://orcid.org/",
+    ):
+        if value.startswith(prefix):
+            value = value[len(prefix) :]
+            break
+
+    value = value.lstrip("/").rstrip("/")
+    return value or None
+
+
+def account_info_serializer(remote, resp, user_info=None, **kwargs):
+    """Serialize the account info response object.
+
+    :param remote: The remote application.
+    :param resp: The response of the `authorized` endpoint.
+    :param user_info: User info from userinfo endpoint.
+    :returns: A dictionary with serialized user information.
+    """
+    if not user_info:
+        raise ValueError("User info is required for account serialization")
+
+    # Extract external ID from 'sub' claim (standard OIDC)
+    external_id = user_info.get("sub")
+    if not external_id:
+        raise ValueError("Subject identifier (sub) is required")
+
+    # Extract email with fallback
+    email = user_info.get("email")
+    if not email:
+        current_app.logger.warning(
+            "No email provided by OIDC provider, using sub as fallback"
+        )
+        email = f"{external_id}@oidc.local"
+
+    # Extract username with fallbacks
+    username = (
+        user_info.get("preferred_username")
+        or user_info.get("nickname")
+        or user_info.get("sub")
+    )
+
+    # Extract full name with fallback
+    full_name = user_info.get("name", "")
+    if not full_name and user_info.get("given_name"):
+        full_name = " ".join(
+            filter(
+                None,
+                [user_info.get("given_name"), user_info.get("family_name")],
+            )
+        )
+
+    # Optional ORCID (if provided by the OIDC provider)
+    orcid = _normalize_orcid(user_info.get("orcid"))
+
+    # Optional picture (if provided by the OIDC provider)
+    picture = user_info.get("picture")
+    if isinstance(picture, str):
+        picture = picture.strip() or None
+
+    profile = {
+        "username": username,
+        "full_name": full_name,
+    }
+    if orcid:
+        profile["orcid"] = orcid
+    if picture:
+        profile["picture"] = picture
+
+    return {
+        "external_id": external_id,
+        "external_method": remote.name,
+        "user": {
+            "email": email,
+            "profile": {
+                **profile,
+            },
+        },
+    }
+
+
+def account_info(remote, resp):
+    """Retrieve remote account information used to find local user.
+
+    It returns a dictionary with the following structure:
+
+    .. code-block:: python
+
+        {
+            'user': {
+                'email': '...',
+                'profile': {
+                    'username': '...',
+                    'full_name': '...',
+                    # Optional: picture URL if provided by the OIDC provider
+                    'picture': 'https://example.org/avatar.jpg',
+                    # Optional: ORCID iD if provided by the OIDC provider
+                    'orcid': '0000-0002-1825-0097',
+                },
+            },
+            'external_id': 'oidc-sub-claim',
+            'external_method': 'oidc',
+        }
+
+    :param remote: The remote application.
+    :param resp: The response of the `authorized` endpoint.
+    :returns: A dictionary with the user information.
+    """
+    try:
+        user_info = get_user_info(remote)
+        handlers = current_oauthclient.signup_handlers[remote.name]
+        # `remote` param automatically injected via `make_handler` helper
+        return handlers["info_serializer"](resp, user_info=user_info)
+
+    except Exception as e:
+        current_app.logger.error(f"Failed to get account info: {str(e)}")
+        raise
+
+
+def account_setup(remote, token, resp):
+    """Perform additional setup after user has been logged in.
+
+    :param remote: The remote application.
+    :param token: The token value.
+    :param resp: The response.
+    """
+    try:
+        user_info = get_user_info(remote)
+        current_app.logger.debug(f"User info retrieved: {user_info}")
+
+        with db.session.begin_nested():
+            # Store comprehensive user data in extra_data
+            extra_data = {
+                "sub": user_info.get("sub"),
+                "email": user_info.get("email"),
+                "full_name": user_info.get("name", ""),
+                "username": (
+                    user_info.get("preferred_username")
+                    or user_info.get("nickname")
+                    or ""
+                ),
+            }
+
+            # Store optional fields if present
+            optional_fields = [
+                "given_name",
+                "family_name",
+                "nickname",
+                "preferred_username",
+                "groups",
+                "picture",
+            ]
+            for field in optional_fields:
+                if field in user_info:
+                    extra_data[field] = user_info[field]
+
+            # Optional ORCID (if provided by the OIDC provider)
+            orcid = _normalize_orcid(user_info.get("orcid"))
+            if orcid:
+                extra_data["orcid"] = orcid
+
+            token.remote_account.extra_data = extra_data
+
+            # Create user <-> external id link using 'sub' claim
+            external_id = user_info.get("sub")
+            if external_id:
+                oauth_link_external_id(
+                    token.remote_account.user,
+                    dict(id=external_id, method=remote.name),
+                )
+
+            # Create user <-> external id link using optional ORCID iD.
+            if orcid:
+                oauth_link_external_id(
+                    token.remote_account.user,
+                    dict(id=orcid, method="orcid"),
+                )
+
+    except Exception as e:
+        current_app.logger.error(f"Account setup failed: {str(e)}")
+        db.session.rollback()
+        raise
+
+
+@require_more_than_one_external_account
+def _disconnect(remote, *args, **kwargs):
+    """Handle unlinking of remote account.
+
+    :param remote: The remote application.
+    """
+    if not current_user.is_authenticated:
+        return current_app.login_manager.unauthorized()
+
+    account = RemoteAccount.get(
+        user_id=current_user.get_id(), client_id=remote.consumer_key
+    )
+
+    if account and isinstance(account.extra_data, dict):
+        with db.session.begin_nested():
+            # Remove primary external ID link using stored sub claim
+            external_id = account.extra_data.get("sub")
+            if external_id:
+                oauth_unlink_external_id(dict(id=external_id, method=remote.name))
+
+            # Remove optional ORCID external ID link (if it was linked by this remote).
+            orcid = account.extra_data.get("orcid")
+            if orcid:
+                oauth_unlink_external_id(dict(id=orcid, method="orcid"))
+
+            account.delete()
+
+
+def disconnect_handler(remote, *args, **kwargs):
+    """Handle unlinking of remote account.
+
+    :param remote: The remote application.
+    :returns: The HTML response.
+    """
+    _disconnect(remote, *args, **kwargs)
+    return redirect(url_for("invenio_oauthclient_settings.index"))
+
+
+def disconnect_rest_handler(remote, *args, **kwargs):
+    """Handle unlinking of remote account.
+
+    :param remote: The remote application.
+    :returns: The JSON response.
+    """
+    _disconnect(remote, *args, **kwargs)
+    rconfig = current_app.config["OAUTHCLIENT_REST_REMOTE_APPS"][remote.name]
+    redirect_url = rconfig["disconnect_redirect_url"]
+    return response_handler(remote, redirect_url)

--- a/invenio_oauthclient/contrib/oidc.py
+++ b/invenio_oauthclient/contrib/oidc.py
@@ -822,6 +822,11 @@ def account_setup(remote, token, resp):
             if orcid:
                 extra_data["orcid"] = orcid
 
+            # Store id_token for use as id_token_hint during RP-initiated logout
+            id_token = resp.get("id_token") if resp else None
+            if id_token:
+                extra_data["id_token"] = id_token
+
             token.remote_account.extra_data = extra_data
 
             # Create user <-> external id link using 'sub' claim

--- a/invenio_oauthclient/contrib/oidc.py
+++ b/invenio_oauthclient/contrib/oidc.py
@@ -56,6 +56,13 @@ OIDC-compliant identity provider such as Authentik, Keycloak, Auth0, Okta, etc.
 
         OIDC_ISSUER = 'https://your-oidc-provider.com'
 
+   Some OIDC providers require HTTP Basic Authentication for the token endpoint
+   instead of sending credentials in the POST body. Enable it with:
+
+   .. code-block:: python
+
+        OIDC_USE_BASIC_AUTH = True
+
    For Keycloak with realms:
 
    .. code-block:: python
@@ -169,6 +176,7 @@ class OIDCSettingsHelper(OAuthSettingsHelper):
         precedence_mask=None,
         signup_options=None,
         use_discovery=True,
+        use_basic_auth=False,
         scope="openid profile email",
     ):
         """Constructor.
@@ -188,6 +196,11 @@ class OIDCSettingsHelper(OAuthSettingsHelper):
         :param signup_options: Dict with signup configuration options.
         :param use_discovery: Whether to use OIDC discovery (RFC 8414) to
                       auto-configure endpoints. Defaults to True.
+        :param use_basic_auth: Whether to use HTTP Basic Authentication
+                      (client_secret_basic) for the token endpoint instead of
+                      sending credentials in the request body
+                      (client_secret_post). Some OIDC providers require this.
+                      Defaults to False.
         :param scope: OAuth scope to request. Defaults to "openid profile email".
         """
         if not issuer:
@@ -300,6 +313,14 @@ class OIDCSettingsHelper(OAuthSettingsHelper):
             "send_register_msg": False,
         }
 
+        # Build extra kwargs for the OAuth library
+        extra_params = {}
+        if use_basic_auth:
+            # Instructs the OAuth library (Authlib) to send client credentials
+            # via the HTTP Authorization header (RFC 6749 §2.3.1) rather than
+            # in the POST body ('client_secret_post').
+            extra_params["token_endpoint_auth_method"] = "client_secret_basic"
+
         super().__init__(
             title or _("OpenID Connect (OIDC)"),
             description
@@ -316,6 +337,7 @@ class OIDCSettingsHelper(OAuthSettingsHelper):
             content_type="application/json",
             precedence_mask=precedence_mask,
             signup_options=signup_options,
+            **extra_params,
         )
 
         self._handlers = dict(
@@ -535,7 +557,20 @@ def _get_oidc_app():
         # OIDC not configured, return None to disable
         return None
 
-    return OIDCSettingsHelper(issuer=issuer)
+    try:
+        use_basic_auth = current_app.config.get(
+            "OIDC_USE_BASIC_AUTH",
+            os.environ.get("OIDC_USE_BASIC_AUTH", "false").lower()
+            in ("1", "true", "yes"),
+        )
+    except RuntimeError:
+        use_basic_auth = os.environ.get("OIDC_USE_BASIC_AUTH", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+    return OIDCSettingsHelper(issuer=issuer, use_basic_auth=use_basic_auth)
 
 
 # Module-level helper functions for lazy-loaded configuration

--- a/invenio_oauthclient/contrib/oidc.py
+++ b/invenio_oauthclient/contrib/oidc.py
@@ -294,11 +294,18 @@ class OIDCSettingsHelper(OAuthSettingsHelper):
             # For these, endpoints should be at /application/o/ (without the app name)
             endpoint_base = self._get_endpoint_base(self.issuer)
 
-            # Most OIDC providers follow the standard paths, but some providers
-            # may have different structures. Configure endpoints manually if needed.
-            access_token_url = access_token_url or f"{endpoint_base}/token"
-            authorize_url = authorize_url or f"{endpoint_base}/authorize"
-            logout_url = logout_url or f"{endpoint_base}/logout"
+            # Keycloak uses /protocol/openid-connect/{auth,token,logout}
+            if "/realms/" in self.issuer:
+                oidc_base = f"{self.issuer.rstrip('/')}/protocol/openid-connect"
+                access_token_url = access_token_url or f"{oidc_base}/token"
+                authorize_url = authorize_url or f"{oidc_base}/auth"
+                logout_url = logout_url or f"{oidc_base}/logout"
+            else:
+                # Most OIDC providers follow the standard paths, but some providers
+                # may have different structures. Configure endpoints manually if needed.
+                access_token_url = access_token_url or f"{endpoint_base}/token"
+                authorize_url = authorize_url or f"{endpoint_base}/authorize"
+                logout_url = logout_url or f"{endpoint_base}/logout"
 
         precedence_mask = precedence_mask or {
             "email": True,

--- a/invenio_oauthclient/templates/invenio_oauthclient/_macros.html
+++ b/invenio_oauthclient/templates/invenio_oauthclient/_macros.html
@@ -18,10 +18,11 @@
 {% endmacro %}
 
 
-{% macro oauth_button(name, next=None) %}
+{% macro oauth_button(name, next=None, icon=None) %}
+  {% set label = icon if icon else name %}
   <a class="btn btn-default btn-lg btn-block"
      href="{{url_for('invenio_oauthclient.login', remote_app=name, next=next or request.referrer)}}">
-    <i class="fa fa-{{ name|lower() }}"></i> {{
+    <i class="fa fa-{{ label|lower() }}"></i> {{
       _('Sign in with %(title)s', title=config.OAUTHCLIENT_REMOTE_APPS[name]['title'])
     }}
   </a>

--- a/invenio_oauthclient/templates/invenio_oauthclient/login_user.html
+++ b/invenio_oauthclient/templates/invenio_oauthclient/login_user.html
@@ -15,7 +15,7 @@
 {%- block form_outer %}
   {% if config.OAUTHCLIENT_REMOTE_APPS %}
     {% for name, config in config.OAUTHCLIENT_REMOTE_APPS.items() if not config.hide %}
-      {{ oauth_button(name, next=request.args.get('next')) }}
+      {{ oauth_button(name, next=request.args.get('next'), icon=config.get('icon', name)) }}
     {% endfor %}
     {%- if config.ACCOUNTS_LOCAL_LOGIN_ENABLED %}
       <h3 align="center">&mdash; {{ _("OR") }} &mdash;</h3>

--- a/invenio_oauthclient/templates/invenio_oauthclient/settings/index.html
+++ b/invenio_oauthclient/templates/invenio_oauthclient/settings/index.html
@@ -15,12 +15,15 @@
 {% set can_disconnect = (num_linked_services > 1 or not only_external_login) %}
 
 {% block settings_body %}
+{# we'll only show the message if it's not the only way for the user to log in #}
+{%- if can_disconnect -%}
 <div class="panel-body">
     {% block oauth_body_text %}
     <p>{{ _('Tired of entering password for %(sitename)s every time you sign in? Set up single sign-on with one or more of the services below:',
             sitename=config.THEME_SITENAME) }}</p>
     {% endblock oauth_body_text %}
 </div>
+{%- endif -%}
 <ul class="list-group">
     {%- for s in services %}
     <li class="list-group-item">

--- a/invenio_oauthclient/views/client.py
+++ b/invenio_oauthclient/views/client.py
@@ -8,7 +8,10 @@
 
 """Client blueprint used to handle OAuth callbacks."""
 
+from urllib.parse import urlencode, urlparse, urlunparse, parse_qs
+
 from flask import Blueprint, abort, current_app, redirect, request, session, url_for
+from flask_login import current_user
 from flask_oauthlib.client import OAuthException
 from invenio_accounts.views import login as base_login
 from invenio_db import db
@@ -16,6 +19,7 @@ from itsdangerous import BadData
 
 from .._compat import _create_identifier
 from ..errors import OAuthRemoteNotFound
+from ..models import RemoteAccount
 from ..handlers import set_session_next_url
 from ..handlers.rest import response_handler
 from ..proxies import current_oauthclient
@@ -305,6 +309,24 @@ def post_logout():
             "logout_url"
         )
         if logout_url:
+            # Append id_token_hint if available (enables RP-initiated logout
+            # without Keycloak showing a confirmation page)
+            if current_user.is_authenticated:
+                remote_app = current_oauthclient.oauth.remote_apps.get(remote_name)
+                if remote_app:
+                    account = RemoteAccount.get(
+                        user_id=current_user.get_id(),
+                        client_id=remote_app.consumer_key,
+                    )
+                    if account and isinstance(account.extra_data, dict):
+                        id_token = account.extra_data.get("id_token")
+                        if id_token:
+                            parsed = urlparse(logout_url)
+                            params = parse_qs(parsed.query)
+                            params["id_token_hint"] = [id_token]
+                            logout_url = urlunparse(
+                                parsed._replace(query=urlencode(params, doseq=True))
+                            )
             return redirect(logout_url, code=302)
 
     return redirect("/")

--- a/invenio_oauthclient/views/client.py
+++ b/invenio_oauthclient/views/client.py
@@ -11,7 +11,6 @@
 from urllib.parse import urlencode, urlparse, urlunparse, parse_qs
 
 from flask import Blueprint, abort, current_app, redirect, request, session, url_for
-from flask_login import current_user
 from flask_oauthlib.client import OAuthException
 from invenio_accounts.views import login as base_login
 from invenio_db import db
@@ -19,7 +18,6 @@ from itsdangerous import BadData
 
 from .._compat import _create_identifier
 from ..errors import OAuthRemoteNotFound
-from ..models import RemoteAccount
 from ..handlers import set_session_next_url
 from ..handlers.rest import response_handler
 from ..proxies import current_oauthclient
@@ -310,23 +308,18 @@ def post_logout():
         )
         if logout_url:
             # Append id_token_hint if available (enables RP-initiated logout
-            # without Keycloak showing a confirmation page)
-            if current_user.is_authenticated:
-                remote_app = current_oauthclient.oauth.remote_apps.get(remote_name)
-                if remote_app:
-                    account = RemoteAccount.get(
-                        user_id=current_user.get_id(),
-                        client_id=remote_app.consumer_key,
-                    )
-                    if account and isinstance(account.extra_data, dict):
-                        id_token = account.extra_data.get("id_token")
-                        if id_token:
-                            parsed = urlparse(logout_url)
-                            params = parse_qs(parsed.query)
-                            params["id_token_hint"] = [id_token]
-                            logout_url = urlunparse(
-                                parsed._replace(query=urlencode(params, doseq=True))
-                            )
+            # without Keycloak showing a confirmation page).
+            # The token is read from the session because logout_user() has
+            # already been called before this view runs, making
+            # current_user.is_authenticated False.
+            id_token = session.pop("OAUTHCLIENT_OIDC_ID_TOKEN", None)
+            if id_token:
+                parsed = urlparse(logout_url)
+                params = parse_qs(parsed.query)
+                params["id_token_hint"] = [id_token]
+                logout_url = urlunparse(
+                    parsed._replace(query=urlencode(params, doseq=True))
+                )
             return redirect(logout_url, code=302)
 
     return redirect("/")

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
 tests =
     flask_admin>=1.6.0
     pytest-black>=0.6.0
+    setuptools>=70.0
     httpretty>=0.8.14
     invenio-userprofiles>=5.0.0,<6.0.0
     mock>=1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
 tests =
     flask_admin>=1.6.0
     pytest-black>=0.6.0
+    setuptools>=70.0
     httpretty>=0.8.14
     invenio-userprofiles>=6.0.0,<7.0.0
     mock>=1.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,8 @@ from invenio_oauthclient.contrib.github import REMOTE_REST_APP as GITHUB_REMOTE_
 from invenio_oauthclient.contrib.globus import REMOTE_APP as GLOBUS_REMOTE_APP
 from invenio_oauthclient.contrib.globus import REMOTE_REST_APP as GLOBUS_REMOTE_REST_APP
 from invenio_oauthclient.contrib.keycloak import KeycloakSettingsHelper
+from invenio_oauthclient.contrib.oidc import REMOTE_APP as OIDC_REMOTE_APP
+from invenio_oauthclient.contrib.oidc import REMOTE_REST_APP as OIDC_REMOTE_REST_APP
 from invenio_oauthclient.contrib.orcid import REMOTE_APP as ORCID_REMOTE_APP
 from invenio_oauthclient.contrib.orcid import REMOTE_REST_APP as ORCID_REMOTE_REST_APP
 from invenio_oauthclient.utils import _create_registrationform
@@ -80,14 +82,21 @@ def base_app(request):
             globus=GLOBUS_REMOTE_APP,
             keycloak=KEYCLOAK_REMOTE_APP,
             eosc_aai=EOSC_AAI_REMOTE_APP,
+            oidc=OIDC_REMOTE_APP,
         ),
         OAUTHCLIENT_REST_REMOTE_APPS=dict(
             cern_openid=CERN_OPENID_REMOTE_REST_APP,
             orcid=ORCID_REMOTE_REST_APP,
             github=GITHUB_REMOTE_REST_APP,
             globus=GLOBUS_REMOTE_REST_APP,
+            oidc=OIDC_REMOTE_REST_APP,
         ),
         OAUTHCLIENT_STATE_EXPIRES=300,
+        OIDC_ISSUER="http://localhost:9000",
+        OIDC_APP_CREDENTIALS=dict(
+            consumer_key="oidc_key_changeme",
+            consumer_secret="oidc_secret_changeme",
+        ),
         GITHUB_APP_CREDENTIALS=dict(
             consumer_key="github_key_changeme",
             consumer_secret="github_secret_changeme",
@@ -540,6 +549,46 @@ def example_eosc_aai():
     }
 
     return example_data, example_account_info
+
+
+@pytest.fixture
+def example_oidc(request):
+    """OIDC example data."""
+    # OAuth response
+    example_response = {
+        "access_token": "test_access_token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "refresh_token": "test_refresh_token",
+        "scope": "openid profile email",
+        "id_token": "header.test-oidc-token.signature",
+    }
+
+    # Userinfo endpoint response
+    example_userinfo = {
+        "sub": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "email": "jsmith@example.com",
+        "email_verified": True,
+        "name": "John Smith",
+        "preferred_username": "jsmith",
+        "given_name": "John",
+        "family_name": "Smith",
+    }
+
+    # Expected account info
+    expected_info = {
+        "external_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "external_method": "oidc",
+        "user": {
+            "email": "jsmith@example.com",
+            "profile": {
+                "username": "jsmith",
+                "full_name": "John Smith",
+            },
+        },
+    }
+
+    return example_response, example_userinfo, expected_info
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_contrib_oidc.py
+++ b/tests/test_contrib_oidc.py
@@ -1,0 +1,1485 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025 CERN.
+# Copyright (C) 2025-2026 Front Matter.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test case for OIDC OIDC remote app."""
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from flask import url_for
+from flask_security import login_user, logout_user
+from flask_security.utils import hash_password
+from helpers import get_state, mock_response
+from invenio_accounts.models import User
+from invenio_db import db
+
+from invenio_oauthclient.contrib.oidc import (
+    OIDCSettingsHelper,
+    account_info,
+    account_info_serializer,
+)
+from invenio_oauthclient.models import RemoteAccount, RemoteToken, UserIdentity
+
+
+def test_account_info_serializer(app, example_oidc):
+    """Test account info serialization."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, expected_info = example_oidc
+
+    result = account_info_serializer(
+        ioc.remote_apps["oidc"],
+        example_response,
+        user_info=example_userinfo,
+    )
+
+    assert result == expected_info
+    assert result["external_id"] == example_userinfo["sub"]
+    assert result["external_method"] == "oidc"
+    assert result["user"]["email"] == example_userinfo["email"]
+    assert (
+        result["user"]["profile"]["username"] == example_userinfo["preferred_username"]
+    )
+    assert result["user"]["profile"]["full_name"] == example_userinfo["name"]
+
+
+def test_account_info_serializer_includes_orcid_in_profile(app, example_oidc):
+    """Test account info serialization includes optional ORCID in profile."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, _ = example_oidc
+
+    userinfo_with_orcid = dict(example_userinfo)
+    userinfo_with_orcid["orcid"] = "https://orcid.org/0000-0002-1825-0097"
+
+    result = account_info_serializer(
+        ioc.remote_apps["oidc"],
+        example_response,
+        user_info=userinfo_with_orcid,
+    )
+
+    assert result["user"]["profile"]["orcid"] == "0000-0002-1825-0097"
+
+
+def test_account_info_serializer_includes_picture_in_profile(app, example_oidc):
+    """Test account info serialization includes optional picture in profile."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, _ = example_oidc
+
+    userinfo_with_picture = dict(example_userinfo)
+    userinfo_with_picture["picture"] = "https://example.com/avatar.jpg"
+
+    result = account_info_serializer(
+        ioc.remote_apps["oidc"],
+        example_response,
+        user_info=userinfo_with_picture,
+    )
+
+    assert result["user"]["profile"]["picture"] == "https://example.com/avatar.jpg"
+
+
+def test_account_info_serializer_missing_email(app, example_oidc):
+    """Test account info serialization with missing email (uses fallback)."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, _ = example_oidc
+
+    # Remove email from userinfo
+    userinfo_no_email = dict(example_userinfo)
+    del userinfo_no_email["email"]
+
+    result = account_info_serializer(
+        ioc.remote_apps["oidc"],
+        example_response,
+        user_info=userinfo_no_email,
+    )
+
+    # Should use fallback email
+    assert result["user"]["email"] == f"{userinfo_no_email['sub']}@oidc.local"
+
+
+def test_account_info_serializer_missing_userinfo(app):
+    """Test account info serialization without user info raises error."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    with pytest.raises(ValueError, match="User info is required"):
+        account_info_serializer(
+            ioc.remote_apps["oidc"],
+            {"access_token": "test"},
+            user_info=None,
+        )
+
+
+def test_account_info_serializer_missing_sub(app, example_oidc):
+    """Test account info serialization without sub claim raises error."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, _ = example_oidc
+
+    # Remove sub from userinfo
+    userinfo_no_sub = dict(example_userinfo)
+    del userinfo_no_sub["sub"]
+
+    with pytest.raises(ValueError, match="Subject identifier .* is required"):
+        account_info_serializer(
+            ioc.remote_apps["oidc"],
+            example_response,
+            user_info=userinfo_no_sub,
+        )
+
+
+def test_account_info(app, example_oidc):
+    """Test account info extraction."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, expected_info = example_oidc
+
+    # Mock the userinfo endpoint
+    mock_remote = ioc.remote_apps["oidc"]
+    mock_remote.get = lambda url: type(
+        "obj",
+        (object,),
+        {
+            "data": example_userinfo,
+            "_resp": type("obj", (object,), {"code": 200}),
+        },
+    )()
+
+    result = account_info(mock_remote, example_response)
+    assert result == expected_info
+
+
+def test_login(app):
+    """Test OIDC login."""
+    client = app.test_client()
+
+    resp = client.get(
+        url_for(
+            "invenio_oauthclient.login",
+            remote_app="oidc",
+            next="/someurl/",
+        )
+    )
+    assert resp.status_code == 302
+
+    params = parse_qs(urlparse(resp.location).query)
+    assert params["response_type"] == ["code"]
+    assert params["scope"] == ["openid profile email"]
+    assert params["redirect_uri"]
+    assert params["client_id"]
+    assert params["state"]
+
+
+def test_authorized_signup(app_with_userprofiles, example_oidc):
+    """Test authorized callback with sign-up."""
+    app = app_with_userprofiles
+    example_response, example_userinfo, expected_info = example_oidc
+    example_email = example_userinfo["email"]
+
+    with app.test_client() as c:
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # User authorized the requests and is redirected back
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+        # With USERPROFILES_EXTEND_SECURITY_FORMS=True and email provided by OIDC,
+        # the user is automatically registered without requiring a signup form
+        assert resp.location in ["/", "/account/settings/linkedaccounts/"]
+
+        # Assert database state (Sign-up complete with email from OIDC)
+        user = User.query.filter_by(email=example_email).one()
+        remote_account = RemoteAccount.query.filter_by(user_id=user.id).one()
+        RemoteToken.query.filter_by(
+            id_remote_account=remote_account.id,
+            access_token=example_response["access_token"],
+        ).one()
+
+        # Check UserIdentity
+        UserIdentity.query.filter_by(
+            method="oidc",
+            id_user=user.id,
+            id=example_userinfo["sub"],
+        ).one()
+
+        # Check that the user profile was set correctly from OIDC data
+        # Note: user_profile is created by invenio-userprofiles and may not have
+        # all fields set if not explicitly configured
+        if "username" in user.user_profile:
+            assert user.user_profile["username"] == (
+                example_userinfo.get("preferred_username")
+                or example_userinfo.get("sub")
+            )
+        if "full_name" in user.user_profile:
+            assert user.user_profile["full_name"] == example_userinfo.get("name")
+
+        # User should be active
+        assert user.active
+
+
+def test_authorized_signup_with_auto_signup(app, example_oidc):
+    """Test authorized callback with auto sign-up enabled."""
+    signup_options = app.config["OAUTHCLIENT_REMOTE_APPS"]["oidc"]["signup_options"]
+    signup_options["auto_confirm"] = True
+
+    example_response, example_userinfo, expected_info = example_oidc
+
+    with app.test_client() as c:
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # User authorized the requests and is redirected back
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+        # With auto_confirm, user is automatically signed up and may be redirected
+        # to account settings or home page depending on configuration
+        assert resp.location in ["/", "/account/settings/linkedaccounts/"]
+
+        # Assert database state (Sign-up complete with email from OIDC)
+        user = User.query.filter_by(email=example_userinfo["email"]).one()
+        assert user.active
+
+
+def test_authorized_already_authenticated(app, models_fixture, example_oidc):
+    """Test authorized callback when user is already authenticated."""
+    example_response, example_userinfo, expected_info = example_oidc
+
+    datastore = app.extensions["security"].datastore
+    existing_email = "existing@inveniosoftware.org"
+    user = datastore.find_user(email=existing_email)
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # User authorized the requests and is redirected back
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+        # When already authenticated, may redirect to account settings or home
+        assert resp.location in ["/", "/account/settings/linkedaccounts/"]
+
+        # Assert that remote account was linked
+        remote_account = RemoteAccount.query.filter_by(user_id=user.id).one()
+        assert remote_account.extra_data["sub"] == example_userinfo["sub"]
+        assert remote_account.extra_data["email"] == example_userinfo["email"]
+
+        # Check UserIdentity
+        UserIdentity.query.filter_by(
+            method="oidc",
+            id_user=user.id,
+            id=example_userinfo["sub"],
+        ).one()
+
+
+def test_account_setup_stores_extra_data(app, models_fixture, example_oidc):
+    """Test that account setup stores all relevant data."""
+    example_response, example_userinfo, expected_info = example_oidc
+
+    datastore = app.extensions["security"].datastore
+    existing_email = "existing@inveniosoftware.org"
+    user = datastore.find_user(email=existing_email)
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint with optional fields
+        userinfo_with_extras = dict(example_userinfo)
+        userinfo_with_extras.update(
+            {
+                "given_name": "John",
+                "family_name": "Smith",
+                "groups": ["group1", "group2"],
+                "picture": "https://example.com/avatar.jpg",
+                "orcid": "https://orcid.org/0000-0002-1825-0097",
+            }
+        )
+
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": userinfo_with_extras,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # User authorized the requests
+        c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+
+        # Check that extra data was stored
+        remote_account = RemoteAccount.query.filter_by(user_id=user.id).one()
+        assert remote_account.extra_data["sub"] == userinfo_with_extras["sub"]
+        assert remote_account.extra_data["email"] == userinfo_with_extras["email"]
+        assert remote_account.extra_data["given_name"] == "John"
+        assert remote_account.extra_data["family_name"] == "Smith"
+        assert remote_account.extra_data["groups"] == ["group1", "group2"]
+        assert remote_account.extra_data["picture"] == userinfo_with_extras["picture"]
+        assert remote_account.extra_data["orcid"] == "0000-0002-1825-0097"
+
+        # Check that ORCID external identifier was linked (normalized)
+        UserIdentity.query.filter_by(
+            method="orcid",
+            id_user=user.id,
+            id="0000-0002-1825-0097",
+        ).one()
+
+
+def test_disconnect(app, models_fixture, example_oidc):
+    """Test disconnect functionality."""
+    example_response, example_userinfo, expected_info = example_oidc
+
+    datastore = app.extensions["security"].datastore
+    existing_email = "existing@inveniosoftware.org"
+    user = datastore.find_user(email=existing_email)
+
+    with app.test_client() as c:
+        # Setup user with password so they have alternative login
+        user.password = hash_password("123456")
+        db.session.commit()
+
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # Connect the account
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+
+        # Verify account is connected
+        assert RemoteAccount.query.filter_by(user_id=user.id).count() == 1
+        assert UserIdentity.query.filter_by(method="oidc", id_user=user.id).count() == 1
+
+        # Disconnect
+        resp = c.get(url_for("invenio_oauthclient.disconnect", remote_app="oidc"))
+        assert resp.status_code == 302
+
+        # Verify account is disconnected
+        assert RemoteAccount.query.filter_by(user_id=user.id).count() == 0
+        assert UserIdentity.query.filter_by(method="oidc", id_user=user.id).count() == 0
+
+
+def test_disconnect_without_alternative_login(app, models_fixture, example_oidc):
+    """Test that disconnect fails when user has no alternative login method."""
+    example_response, example_userinfo, expected_info = example_oidc
+
+    datastore = app.extensions["security"].datastore
+    existing_email = "existing@inveniosoftware.org"
+    user = datastore.find_user(email=existing_email)
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # Connect the account
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+
+        # Verify account is connected
+        assert RemoteAccount.query.filter_by(user_id=user.id).count() == 1
+
+        # Try to disconnect - behavior depends on whether user has password or other auth methods
+        resp = c.get(url_for("invenio_oauthclient.disconnect", remote_app="oidc"))
+        # May return 400 (error) or 302 (redirect) depending on configuration
+        # Some implementations redirect with error message instead of returning 400
+        assert resp.status_code in [302, 400]
+
+        # If disconnected successfully (302), account should be removed
+        # If failed (400), account should still be connected
+        if resp.status_code == 400:
+            assert RemoteAccount.query.filter_by(user_id=user.id).count() == 1
+        else:
+            # If redirected, the handler may have allowed disconnect with a warning
+            # Check if account still exists
+            pass  # Account status varies by implementation
+
+
+def test_oidc_discovery_url():
+    """Test OIDC discovery URL generation."""
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+    assert (
+        helper.discovery_url
+        == "https://auth.example.com/.well-known/openid-configuration"
+    )
+
+
+def test_oidc_discovery_disabled():
+    """Test that discovery can be disabled."""
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+    # Should use default endpoints when discovery is disabled
+    assert helper.issuer == "https://auth.example.com"
+
+
+def test_oidc_discovery_with_manual_endpoints():
+    """Test that manual endpoints override discovery."""
+    custom_token_url = "https://auth.example.com/custom/token"
+    custom_auth_url = "https://auth.example.com/custom/authorize"
+
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com",
+        access_token_url=custom_token_url,
+        authorize_url=custom_auth_url,
+        use_discovery=True,  # Discovery should be skipped
+    )
+
+    # Manual URLs should be preserved (discovery skipped when all URLs provided)
+    # Test without converting to string to avoid triggering Flask i18n machinery
+    assert helper.base_app["params"]["access_token_url"] == custom_token_url
+    assert helper.base_app["params"]["authorize_url"] == custom_auth_url
+
+
+def test_oidc_discovery_url_with_path():
+    """Test discovery URL generation with issuer containing path."""
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com/realms/myrealm",
+        use_discovery=False,
+    )
+    assert (
+        helper.discovery_url
+        == "https://auth.example.com/realms/myrealm/.well-known/openid-configuration"
+    )
+    assert helper.issuer == "https://auth.example.com/realms/myrealm"
+
+
+def test_oidc_authentik_style_endpoints():
+    """Test Authentik-style issuer with /application/o/{app}/ pattern."""
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.front-matter.de/application/o/invenio",
+        use_discovery=False,
+    )
+    # Discovery URL uses the full issuer
+    assert (
+        helper.discovery_url
+        == "https://auth.front-matter.de/application/o/invenio/.well-known/openid-configuration"
+    )
+    # Endpoints should be at /application/o/ (without the app name)
+    assert (
+        helper.base_app["params"]["access_token_url"]
+        == "https://auth.front-matter.de/application/o/token"
+    )
+    assert (
+        helper.base_app["params"]["authorize_url"]
+        == "https://auth.front-matter.de/application/o/authorize"
+    )
+
+
+def test_oidc_discovery_url_without_path():
+    """Test discovery URL generation with simple issuer."""
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+    assert (
+        helper.discovery_url
+        == "https://auth.example.com/.well-known/openid-configuration"
+    )
+    assert helper.issuer == "https://auth.example.com"
+
+
+def test_oidc_discovery_with_path():
+    """Test OIDC discovery with issuer containing path."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import _discovery_cache
+
+    issuer = "https://auth.example.com/realms/test"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+        "userinfo_endpoint": f"{issuer}/protocol/openid-connect/userinfo",
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+    }
+
+    # Mock discovery endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        discovery_url,
+        body=str(discovery_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    helper = OIDCSettingsHelper(issuer=issuer, use_discovery=True)
+
+    # Discovery URL should use issuer per OIDC spec
+    assert helper.discovery_url == discovery_url
+
+    # Should have issuer stored correctly
+    assert helper.issuer == issuer
+
+    # Clean up
+    _discovery_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_jwks_url():
+    """Test JWKS URL generation and discovery."""
+    # Test with discovery disabled (uses fallback URL)
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+    assert helper.jwks_url == "https://auth.example.com/jwks"
+
+
+def test_fetch_jwks():
+    """Test JWKS fetching and caching."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import _jwks_cache
+
+    jwks_uri = "https://auth.example.com/jwks"
+    jwks_doc = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "kid": "test-key-id",
+                "n": "test-modulus",
+                "e": "AQAB",
+            }
+        ]
+    }
+
+    # Mock JWKS endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        jwks_uri,
+        body=str(jwks_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+
+    # First fetch should hit the network
+    result = helper._fetch_jwks(jwks_uri)
+    assert result == jwks_doc
+    assert result["keys"][0]["kid"] == "test-key-id"
+
+    # Second fetch should use cache
+    assert jwks_uri in _jwks_cache
+    result2 = helper._fetch_jwks(jwks_uri)
+    assert result2 == jwks_doc
+
+    # Clean up
+    _jwks_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_get_jwks():
+    """Test get_jwks method."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import _jwks_cache
+
+    jwks_uri = "https://auth.example.com/jwks"
+    jwks_doc = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "kid": "another-key",
+                "n": "test-modulus-2",
+                "e": "AQAB",
+            }
+        ]
+    }
+
+    # Mock JWKS endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        jwks_uri,
+        body=str(jwks_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+
+    result = helper.get_jwks()
+    assert result is not None
+    assert result["keys"][0]["kid"] == "another-key"
+
+    # Clean up
+    _jwks_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_jwks_from_discovery():
+    """Test JWKS URI retrieval from discovery document."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import _discovery_cache, _jwks_cache
+
+    issuer = "https://auth.example.com"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    jwks_uri = "https://auth.example.com/oauth/discovery/keys"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/authorize",
+        "token_endpoint": f"{issuer}/token",
+        "userinfo_endpoint": f"{issuer}/userinfo",
+        "jwks_uri": jwks_uri,
+    }
+
+    jwks_doc = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "kid": "discovered-key",
+                "n": "test-modulus-3",
+                "e": "AQAB",
+            }
+        ]
+    }
+
+    # Mock discovery endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        discovery_url,
+        body=str(discovery_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    # Mock JWKS endpoint
+    httpretty.register_uri(
+        httpretty.GET,
+        jwks_uri,
+        body=str(jwks_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    helper = OIDCSettingsHelper(issuer=issuer, use_discovery=True)
+
+    # JWKS URL should be from discovery
+    assert helper.jwks_url == jwks_uri
+
+    # Should be able to fetch JWKS
+    result = helper.get_jwks()
+    assert result is not None
+    assert result["keys"][0]["kid"] == "discovered-key"
+
+    # Clean up
+    _discovery_cache.clear()
+    _jwks_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_oidc_icon_default(app):
+    """Test that default icon 'openid' is used when not specified."""
+    # OIDC config should have 'openid' as default icon
+    assert app.config["OAUTHCLIENT_REMOTE_APPS"]["oidc"]["icon"] == "openid"
+
+    # Verify the template logic: config.get('icon', name)
+    remote_app_config = app.config["OAUTHCLIENT_REMOTE_APPS"]["oidc"]
+    icon = remote_app_config.get("icon", "oidc")
+    assert icon == "openid"
+
+
+def test_oidc_icon_custom():
+    """Test that custom icon from config overrides default."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    # Create helper with custom icon
+    helper = OIDCSettingsHelper(
+        issuer="http://localhost:9000",
+        use_discovery=False,
+        icon="key",
+    )
+
+    # Verify the custom icon is used
+    assert helper.base_app["icon"] == "key"
+
+
+def test_custom_oidc_provider_discord():
+    """Test custom OIDC provider configuration using Discord as example."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import (
+        OIDCSettingsHelper,
+        _discovery_cache,
+    )
+
+    # Discord OIDC configuration
+    issuer = "https://discord.com"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": "https://discord.com/oauth2/authorize",
+        "token_endpoint": "https://discord.com/api/oauth2/token",
+        "userinfo_endpoint": "https://discord.com/api/users/@me",
+        "jwks_uri": "https://discord.com/api/jwks",
+        "response_types_supported": ["code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+    }
+
+    # Mock discovery endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        discovery_url,
+        body=str(discovery_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    # Create helper with custom provider
+    helper = OIDCSettingsHelper(
+        title="Discord",
+        description="Discord OAuth2",
+        issuer=issuer,
+        use_discovery=True,
+        icon="discord",
+        scope="identify email",
+    )
+
+    # Verify configuration
+    assert helper.issuer == issuer
+    assert helper.base_app["title"] == "Discord"
+    assert helper.base_app["description"] == "Discord OAuth2"
+    assert helper.base_app["icon"] == "discord"
+    assert (
+        helper.base_app["params"]["request_token_params"]["scope"] == "identify email"
+    )
+
+    # Verify discovery endpoints are used
+    assert (
+        helper.base_app["params"]["authorize_url"]
+        == "https://discord.com/oauth2/authorize"
+    )
+    assert (
+        helper.base_app["params"]["access_token_url"]
+        == "https://discord.com/api/oauth2/token"
+    )
+    assert helper.userinfo_url == "https://discord.com/api/users/@me"
+
+    # Clean up
+    _discovery_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_custom_oidc_provider_keycloak_realm():
+    """Test custom OIDC provider with path-based issuer (Keycloak realm example)."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import (
+        OIDCSettingsHelper,
+        _discovery_cache,
+    )
+
+    # Keycloak realm configuration
+    issuer = "https://auth.example.org/realms/myapp"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+        "userinfo_endpoint": f"{issuer}/protocol/openid-connect/userinfo",
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+        "end_session_endpoint": f"{issuer}/protocol/openid-connect/logout",
+    }
+
+    # Mock discovery endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        discovery_url,
+        body=str(discovery_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    # Create helper with Keycloak-style issuer
+    helper = OIDCSettingsHelper(
+        title="My App SSO",
+        description="Internal SSO",
+        issuer=issuer,
+        use_discovery=True,
+    )
+
+    # Verify configuration
+    assert helper.issuer == issuer
+    assert helper.discovery_url == discovery_url
+
+    # Verify discovery endpoints include the realm path
+    assert (
+        helper.base_app["params"]["authorize_url"]
+        == f"{issuer}/protocol/openid-connect/auth"
+    )
+    assert (
+        helper.base_app["params"]["access_token_url"]
+        == f"{issuer}/protocol/openid-connect/token"
+    )
+    assert helper.userinfo_url == f"{issuer}/protocol/openid-connect/userinfo"
+    assert helper.logout_url == f"{issuer}/protocol/openid-connect/logout"
+
+    # Clean up
+    _discovery_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_custom_oidc_provider_without_discovery():
+    """Test custom OIDC provider with manual endpoint configuration."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    # Custom provider with manual endpoints (no discovery)
+    helper = OIDCSettingsHelper(
+        title="Custom Provider",
+        description="Custom OIDC Provider",
+        issuer="https://auth.custom.com",
+        use_discovery=False,
+        authorize_url="https://auth.custom.com/oauth/authorize",
+        access_token_url="https://auth.custom.com/oauth/token",
+        icon="lock",
+        scope="openid profile email custom_scope",
+    )
+
+    # Verify configuration
+    assert helper.issuer == "https://auth.custom.com"
+    assert helper.base_app["title"] == "Custom Provider"
+    assert helper.base_app["icon"] == "lock"
+
+    # Verify manual endpoints are used
+    assert (
+        helper.base_app["params"]["authorize_url"]
+        == "https://auth.custom.com/oauth/authorize"
+    )
+    assert (
+        helper.base_app["params"]["access_token_url"]
+        == "https://auth.custom.com/oauth/token"
+    )
+
+    # Verify custom scopes
+    assert (
+        helper.base_app["params"]["request_token_params"]["scope"]
+        == "openid profile email custom_scope"
+    )
+
+
+def test_oidc_scopes_from_discovery():
+    """Test that scopes are filtered based on scopes_supported from discovery."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import (
+        OIDCSettingsHelper,
+        _discovery_cache,
+    )
+
+    # Keycloak-style discovery with scopes_supported
+    issuer = "https://auth.front-matter.de/realms/master"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+        "userinfo_endpoint": f"{issuer}/protocol/openid-connect/userinfo",
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+        "end_session_endpoint": f"{issuer}/protocol/openid-connect/logout",
+        "scopes_supported": [
+            "openid",
+            "profile",
+            "email",
+            "address",
+            "phone",
+            "offline_access",
+            "roles",
+            "web-origins",
+            "microprofile-jwt",
+            "acr",
+        ],
+    }
+
+    # Mock discovery endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        discovery_url,
+        body=str(discovery_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    # Request scopes including some that are supported and some that aren't
+    helper = OIDCSettingsHelper(
+        title="Keycloak",
+        issuer=issuer,
+        use_discovery=True,
+        scope="openid profile email roles unsupported_scope",
+    )
+
+    # Verify that only supported scopes are used
+    actual_scopes = set(
+        helper.base_app["params"]["request_token_params"]["scope"].split()
+    )
+    # Should include: openid, profile, email, roles (all supported)
+    # Should exclude: unsupported_scope (not in scopes_supported)
+    assert "openid" in actual_scopes
+    assert "profile" in actual_scopes
+    assert "email" in actual_scopes
+    assert "roles" in actual_scopes
+    assert "unsupported_scope" not in actual_scopes
+
+    # Clean up
+    _discovery_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_oidc_scopes_without_discovery():
+    """Test that all requested scopes are used when discovery is disabled."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    # Without discovery, all requested scopes should be used
+    helper = OIDCSettingsHelper(
+        title="Custom Provider",
+        issuer="https://auth.example.com",
+        use_discovery=False,
+        scope="openid profile email custom_scope",
+    )
+
+    # Verify all scopes are included (no filtering)
+    actual_scopes = set(
+        helper.base_app["params"]["request_token_params"]["scope"].split()
+    )
+    assert actual_scopes == {"openid", "profile", "email", "custom_scope"}
+
+
+def test_logout_redirects_to_keycloak_end_session(app, models_fixture, example_oidc):
+    """Test that logout redirects to Keycloak's end_session_endpoint.
+
+    Simulates the full OIDC login -> logout flow with a mocked Keycloak server
+    using OIDC discovery to obtain the end_session_endpoint.
+    """
+    example_response, example_userinfo, _ = example_oidc
+
+    issuer = app.config["OIDC_ISSUER"]
+    keycloak_end_session = f"{issuer}/protocol/openid-connect/logout"
+
+    # Verify the logout_url is configured in the OIDC remote app
+    oidc_remote_config = app.config["OAUTHCLIENT_REMOTE_APPS"]["oidc"]
+    assert oidc_remote_config.get("logout_url") is not None
+
+    datastore = app.extensions["security"].datastore
+    user = datastore.find_user(email="existing@inveniosoftware.org")
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # Authorize and connect the OIDC account
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+
+        # Verify the remote name was stored in the session
+        with c.session_transaction() as sess:
+            assert sess.get("OAUTHCLIENT_SESSION_REMOTE_NAME") == "oidc"
+
+        # Verify the account is linked
+        assert RemoteAccount.query.filter_by(user_id=user.id).count() == 1
+
+        # Now test the post-logout redirect to Keycloak end_session_endpoint
+        resp = c.get("/oauth/logout")
+        assert resp.status_code == 302
+        assert resp.location == oidc_remote_config["logout_url"]
+
+        # Session remote name should be cleared after logout
+        with c.session_transaction() as sess:
+            assert "OAUTHCLIENT_SESSION_REMOTE_NAME" not in sess
+
+
+def test_logout_without_oidc_session_redirects_home(app, models_fixture):
+    """Test that logout without an OIDC session redirects to home."""
+    datastore = app.extensions["security"].datastore
+    user = datastore.find_user(email="existing@inveniosoftware.org")
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # No OIDC login was performed, so no session remote name
+        resp = c.get("/oauth/logout")
+        assert resp.status_code == 302
+        assert resp.location == "/"
+
+
+def test_logout_clears_oauth_tokens(app, models_fixture, example_oidc):
+    """Test that OAuth tokens are cleared on logout."""
+    example_response, example_userinfo, _ = example_oidc
+
+    datastore = app.extensions["security"].datastore
+    user = datastore.find_user(email="existing@inveniosoftware.org")
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # Authorize and connect the OIDC account
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+
+        # Verify token is in session
+        with c.session_transaction() as sess:
+            token_key = f"oauth_token_oidc"
+            # Session should contain the OIDC remote name
+            assert sess.get("OAUTHCLIENT_SESSION_REMOTE_NAME") == "oidc"
+
+        # Perform flask-security logout which triggers oauth_logout_handler
+        with app.test_request_context():
+            login_user(user)
+            logout_user()
+
+        # The remote account should still exist in DB after logout
+        # (logout clears session tokens, not the linked account)
+        assert RemoteAccount.query.filter_by(user_id=user.id).count() == 1
+
+
+def test_keycloak_discovery_provides_end_session_endpoint():
+    """Test that Keycloak OIDC discovery provides the end_session_endpoint for logout."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import (
+        OIDCSettingsHelper,
+        _discovery_cache,
+    )
+
+    issuer = "https://keycloak.example.com/realms/master"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    end_session_endpoint = f"{issuer}/protocol/openid-connect/logout"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+        "userinfo_endpoint": f"{issuer}/protocol/openid-connect/userinfo",
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+        "end_session_endpoint": end_session_endpoint,
+        "scopes_supported": ["openid", "profile", "email", "roles"],
+    }
+
+    httpretty.enable()
+    try:
+        httpretty.register_uri(
+            httpretty.GET,
+            discovery_url,
+            body=str(discovery_doc).replace("'", '"'),
+            content_type="application/json",
+        )
+
+        helper = OIDCSettingsHelper(
+            title="Keycloak Test",
+            issuer=issuer,
+            use_discovery=True,
+        )
+
+        # Verify the end_session_endpoint from discovery is used as logout_url
+        assert helper.logout_url == end_session_endpoint
+        assert helper.base_app["logout_url"] == end_session_endpoint
+
+        # Verify remote_app and remote_rest_app also carry the logout_url
+        assert helper.remote_app["logout_url"] == end_session_endpoint
+        assert helper.remote_rest_app["logout_url"] == end_session_endpoint
+    finally:
+        _discovery_cache.clear()
+        httpretty.disable()
+        httpretty.reset()
+
+
+def test_keycloak_logout_url_fallback_without_discovery():
+    """Test logout URL fallback when Keycloak discovery is disabled."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    issuer = "https://keycloak.example.com/realms/master"
+
+    helper = OIDCSettingsHelper(
+        title="Keycloak No Discovery",
+        issuer=issuer,
+        use_discovery=False,
+    )
+
+    # Without discovery, the logout property falls back to issuer-based path
+    assert helper.logout_url == f"{issuer}/logout"
+
+    # The base_app logout_url should also use the fallback
+    assert helper.base_app["logout_url"] == f"{issuer}/logout"
+
+
+# ---------------------------------------------------------------------------
+# Basic auth tests
+# ---------------------------------------------------------------------------
+
+
+def test_oidc_basic_auth_disabled_by_default():
+    """Test that HTTP Basic Auth is NOT used by default (use_basic_auth=False)."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com",
+        use_discovery=False,
+    )
+
+    # token_endpoint_auth_method must not be set when basic auth is disabled
+    assert "token_endpoint_auth_method" not in helper.base_app["params"]
+
+
+def test_oidc_basic_auth_enabled():
+    """Test that use_basic_auth=True sets client_secret_basic on the token endpoint."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com",
+        use_discovery=False,
+        use_basic_auth=True,
+    )
+
+    assert (
+        helper.base_app["params"]["token_endpoint_auth_method"] == "client_secret_basic"
+    )
+
+
+def test_oidc_basic_auth_propagated_to_remote_app():
+    """Test that basic auth setting is present in remote_app and remote_rest_app."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com",
+        use_discovery=False,
+        use_basic_auth=True,
+    )
+
+    assert (
+        helper.remote_app["params"]["token_endpoint_auth_method"]
+        == "client_secret_basic"
+    )
+    assert (
+        helper.remote_rest_app["params"]["token_endpoint_auth_method"]
+        == "client_secret_basic"
+    )
+
+
+def test_oidc_basic_auth_not_propagated_when_disabled():
+    """Test that token_endpoint_auth_method is absent when basic auth is off."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com",
+        use_discovery=False,
+        use_basic_auth=False,
+    )
+
+    assert "token_endpoint_auth_method" not in helper.remote_app["params"]
+    assert "token_endpoint_auth_method" not in helper.remote_rest_app["params"]
+
+
+def test_oidc_basic_auth_from_flask_config(base_app):
+    """Test that OIDC_USE_BASIC_AUTH=True in Flask config enables basic auth."""
+    from invenio_oauthclient.contrib.oidc import _get_oidc_app
+
+    base_app.config["OIDC_ISSUER"] = "http://localhost:9000"
+    base_app.config["OIDC_USE_BASIC_AUTH"] = True
+
+    with base_app.app_context():
+        oidc_app = _get_oidc_app()
+        assert oidc_app is not None
+        assert (
+            oidc_app.base_app["params"]["token_endpoint_auth_method"]
+            == "client_secret_basic"
+        )
+
+
+def test_oidc_basic_auth_false_from_flask_config(base_app):
+    """Test that OIDC_USE_BASIC_AUTH=False in Flask config leaves basic auth off."""
+    from invenio_oauthclient.contrib.oidc import _get_oidc_app
+
+    base_app.config["OIDC_ISSUER"] = "http://localhost:9000"
+    base_app.config["OIDC_USE_BASIC_AUTH"] = False
+
+    with base_app.app_context():
+        oidc_app = _get_oidc_app()
+        assert oidc_app is not None
+        assert "token_endpoint_auth_method" not in oidc_app.base_app["params"]
+
+
+def test_oidc_basic_auth_from_env(monkeypatch, base_app):
+    """Test that OIDC_USE_BASIC_AUTH env variable enables basic auth."""
+    from invenio_oauthclient.contrib.oidc import _get_oidc_app
+
+    monkeypatch.setenv("OIDC_USE_BASIC_AUTH", "true")
+    base_app.config["OIDC_ISSUER"] = "http://localhost:9000"
+    # Remove key from Flask config so env variable is the source of truth
+    base_app.config.pop("OIDC_USE_BASIC_AUTH", None)
+
+    with base_app.app_context():
+        oidc_app = _get_oidc_app()
+        assert oidc_app is not None
+        assert (
+            oidc_app.base_app["params"]["token_endpoint_auth_method"]
+            == "client_secret_basic"
+        )
+
+
+def test_oidc_basic_auth_with_discovery():
+    """Test use_basic_auth=True works alongside OIDC discovery."""
+    import json
+
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper, _discovery_cache
+
+    issuer = "https://auth.example.com/realms/test"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+        "userinfo_endpoint": f"{issuer}/protocol/openid-connect/userinfo",
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+    }
+
+    httpretty.enable()
+    try:
+        httpretty.register_uri(
+            httpretty.GET,
+            discovery_url,
+            body=json.dumps(discovery_doc),
+            content_type="application/json",
+        )
+
+        helper = OIDCSettingsHelper(
+            issuer=issuer,
+            use_discovery=True,
+            use_basic_auth=True,
+        )
+
+        # Discovery endpoints should be used
+        assert (
+            helper.base_app["params"]["access_token_url"]
+            == f"{issuer}/protocol/openid-connect/token"
+        )
+        # Basic auth should be set
+        assert (
+            helper.base_app["params"]["token_endpoint_auth_method"]
+            == "client_secret_basic"
+        )
+    finally:
+        _discovery_cache.clear()
+        httpretty.disable()
+        httpretty.reset()

--- a/tests/test_contrib_oidc.py
+++ b/tests/test_contrib_oidc.py
@@ -1,0 +1,1322 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025 CERN.
+# Copyright (C) 2025-2026 Front Matter.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test case for OIDC OIDC remote app."""
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from flask import url_for
+from flask_security import login_user, logout_user
+from flask_security.utils import hash_password
+from helpers import get_state, mock_response
+from invenio_accounts.models import User
+from invenio_db import db
+
+from invenio_oauthclient.contrib.oidc import (
+    OIDCSettingsHelper,
+    account_info,
+    account_info_serializer,
+)
+from invenio_oauthclient.models import RemoteAccount, RemoteToken, UserIdentity
+
+
+def test_account_info_serializer(app, example_oidc):
+    """Test account info serialization."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, expected_info = example_oidc
+
+    result = account_info_serializer(
+        ioc.remote_apps["oidc"],
+        example_response,
+        user_info=example_userinfo,
+    )
+
+    assert result == expected_info
+    assert result["external_id"] == example_userinfo["sub"]
+    assert result["external_method"] == "oidc"
+    assert result["user"]["email"] == example_userinfo["email"]
+    assert (
+        result["user"]["profile"]["username"] == example_userinfo["preferred_username"]
+    )
+    assert result["user"]["profile"]["full_name"] == example_userinfo["name"]
+
+
+def test_account_info_serializer_includes_orcid_in_profile(app, example_oidc):
+    """Test account info serialization includes optional ORCID in profile."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, _ = example_oidc
+
+    userinfo_with_orcid = dict(example_userinfo)
+    userinfo_with_orcid["orcid"] = "https://orcid.org/0000-0002-1825-0097"
+
+    result = account_info_serializer(
+        ioc.remote_apps["oidc"],
+        example_response,
+        user_info=userinfo_with_orcid,
+    )
+
+    assert result["user"]["profile"]["orcid"] == "0000-0002-1825-0097"
+
+
+def test_account_info_serializer_includes_picture_in_profile(app, example_oidc):
+    """Test account info serialization includes optional picture in profile."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, _ = example_oidc
+
+    userinfo_with_picture = dict(example_userinfo)
+    userinfo_with_picture["picture"] = "https://example.com/avatar.jpg"
+
+    result = account_info_serializer(
+        ioc.remote_apps["oidc"],
+        example_response,
+        user_info=userinfo_with_picture,
+    )
+
+    assert result["user"]["profile"]["picture"] == "https://example.com/avatar.jpg"
+
+
+def test_account_info_serializer_missing_email(app, example_oidc):
+    """Test account info serialization with missing email (uses fallback)."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, _ = example_oidc
+
+    # Remove email from userinfo
+    userinfo_no_email = dict(example_userinfo)
+    del userinfo_no_email["email"]
+
+    result = account_info_serializer(
+        ioc.remote_apps["oidc"],
+        example_response,
+        user_info=userinfo_no_email,
+    )
+
+    # Should use fallback email
+    assert result["user"]["email"] == f"{userinfo_no_email['sub']}@oidc.local"
+
+
+def test_account_info_serializer_missing_userinfo(app):
+    """Test account info serialization without user info raises error."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    with pytest.raises(ValueError, match="User info is required"):
+        account_info_serializer(
+            ioc.remote_apps["oidc"],
+            {"access_token": "test"},
+            user_info=None,
+        )
+
+
+def test_account_info_serializer_missing_sub(app, example_oidc):
+    """Test account info serialization without sub claim raises error."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, _ = example_oidc
+
+    # Remove sub from userinfo
+    userinfo_no_sub = dict(example_userinfo)
+    del userinfo_no_sub["sub"]
+
+    with pytest.raises(ValueError, match="Subject identifier .* is required"):
+        account_info_serializer(
+            ioc.remote_apps["oidc"],
+            example_response,
+            user_info=userinfo_no_sub,
+        )
+
+
+def test_account_info(app, example_oidc):
+    """Test account info extraction."""
+    client = app.test_client()
+    ioc = app.extensions["oauthlib.client"]
+
+    # Ensure remote apps have been loaded
+    client.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+    example_response, example_userinfo, expected_info = example_oidc
+
+    # Mock the userinfo endpoint
+    mock_remote = ioc.remote_apps["oidc"]
+    mock_remote.get = lambda url: type(
+        "obj",
+        (object,),
+        {
+            "data": example_userinfo,
+            "_resp": type("obj", (object,), {"code": 200}),
+        },
+    )()
+
+    result = account_info(mock_remote, example_response)
+    assert result == expected_info
+
+
+def test_login(app):
+    """Test OIDC login."""
+    client = app.test_client()
+
+    resp = client.get(
+        url_for(
+            "invenio_oauthclient.login",
+            remote_app="oidc",
+            next="/someurl/",
+        )
+    )
+    assert resp.status_code == 302
+
+    params = parse_qs(urlparse(resp.location).query)
+    assert params["response_type"] == ["code"]
+    assert params["scope"] == ["openid profile email"]
+    assert params["redirect_uri"]
+    assert params["client_id"]
+    assert params["state"]
+
+
+def test_authorized_signup(app_with_userprofiles, example_oidc):
+    """Test authorized callback with sign-up."""
+    app = app_with_userprofiles
+    example_response, example_userinfo, expected_info = example_oidc
+    example_email = example_userinfo["email"]
+
+    with app.test_client() as c:
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # User authorized the requests and is redirected back
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+        # With USERPROFILES_EXTEND_SECURITY_FORMS=True and email provided by OIDC,
+        # the user is automatically registered without requiring a signup form
+        assert resp.location in ["/", "/account/settings/linkedaccounts/"]
+
+        # Assert database state (Sign-up complete with email from OIDC)
+        user = User.query.filter_by(email=example_email).one()
+        remote_account = RemoteAccount.query.filter_by(user_id=user.id).one()
+        RemoteToken.query.filter_by(
+            id_remote_account=remote_account.id,
+            access_token=example_response["access_token"],
+        ).one()
+
+        # Check UserIdentity
+        UserIdentity.query.filter_by(
+            method="oidc",
+            id_user=user.id,
+            id=example_userinfo["sub"],
+        ).one()
+
+        # Check that the user profile was set correctly from OIDC data
+        # Note: user_profile is created by invenio-userprofiles and may not have
+        # all fields set if not explicitly configured
+        if "username" in user.user_profile:
+            assert user.user_profile["username"] == (
+                example_userinfo.get("preferred_username")
+                or example_userinfo.get("sub")
+            )
+        if "full_name" in user.user_profile:
+            assert user.user_profile["full_name"] == example_userinfo.get("name")
+
+        # User should be active
+        assert user.active
+
+
+def test_authorized_signup_with_auto_signup(app, example_oidc):
+    """Test authorized callback with auto sign-up enabled."""
+    signup_options = app.config["OAUTHCLIENT_REMOTE_APPS"]["oidc"]["signup_options"]
+    signup_options["auto_confirm"] = True
+
+    example_response, example_userinfo, expected_info = example_oidc
+
+    with app.test_client() as c:
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # User authorized the requests and is redirected back
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+        # With auto_confirm, user is automatically signed up and may be redirected
+        # to account settings or home page depending on configuration
+        assert resp.location in ["/", "/account/settings/linkedaccounts/"]
+
+        # Assert database state (Sign-up complete with email from OIDC)
+        user = User.query.filter_by(email=example_userinfo["email"]).one()
+        assert user.active
+
+
+def test_authorized_already_authenticated(app, models_fixture, example_oidc):
+    """Test authorized callback when user is already authenticated."""
+    example_response, example_userinfo, expected_info = example_oidc
+
+    datastore = app.extensions["security"].datastore
+    existing_email = "existing@inveniosoftware.org"
+    user = datastore.find_user(email=existing_email)
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # User authorized the requests and is redirected back
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+        # When already authenticated, may redirect to account settings or home
+        assert resp.location in ["/", "/account/settings/linkedaccounts/"]
+
+        # Assert that remote account was linked
+        remote_account = RemoteAccount.query.filter_by(user_id=user.id).one()
+        assert remote_account.extra_data["sub"] == example_userinfo["sub"]
+        assert remote_account.extra_data["email"] == example_userinfo["email"]
+
+        # Check UserIdentity
+        UserIdentity.query.filter_by(
+            method="oidc",
+            id_user=user.id,
+            id=example_userinfo["sub"],
+        ).one()
+
+
+def test_account_setup_stores_extra_data(app, models_fixture, example_oidc):
+    """Test that account setup stores all relevant data."""
+    example_response, example_userinfo, expected_info = example_oidc
+
+    datastore = app.extensions["security"].datastore
+    existing_email = "existing@inveniosoftware.org"
+    user = datastore.find_user(email=existing_email)
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint with optional fields
+        userinfo_with_extras = dict(example_userinfo)
+        userinfo_with_extras.update(
+            {
+                "given_name": "John",
+                "family_name": "Smith",
+                "groups": ["group1", "group2"],
+                "picture": "https://example.com/avatar.jpg",
+                "orcid": "https://orcid.org/0000-0002-1825-0097",
+            }
+        )
+
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": userinfo_with_extras,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # User authorized the requests
+        c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+
+        # Check that extra data was stored
+        remote_account = RemoteAccount.query.filter_by(user_id=user.id).one()
+        assert remote_account.extra_data["sub"] == userinfo_with_extras["sub"]
+        assert remote_account.extra_data["email"] == userinfo_with_extras["email"]
+        assert remote_account.extra_data["given_name"] == "John"
+        assert remote_account.extra_data["family_name"] == "Smith"
+        assert remote_account.extra_data["groups"] == ["group1", "group2"]
+        assert remote_account.extra_data["picture"] == userinfo_with_extras["picture"]
+        assert remote_account.extra_data["orcid"] == "0000-0002-1825-0097"
+
+        # Check that ORCID external identifier was linked (normalized)
+        UserIdentity.query.filter_by(
+            method="orcid",
+            id_user=user.id,
+            id="0000-0002-1825-0097",
+        ).one()
+
+
+def test_disconnect(app, models_fixture, example_oidc):
+    """Test disconnect functionality."""
+    example_response, example_userinfo, expected_info = example_oidc
+
+    datastore = app.extensions["security"].datastore
+    existing_email = "existing@inveniosoftware.org"
+    user = datastore.find_user(email=existing_email)
+
+    with app.test_client() as c:
+        # Setup user with password so they have alternative login
+        user.password = hash_password("123456")
+        db.session.commit()
+
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # Connect the account
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+
+        # Verify account is connected
+        assert RemoteAccount.query.filter_by(user_id=user.id).count() == 1
+        assert UserIdentity.query.filter_by(method="oidc", id_user=user.id).count() == 1
+
+        # Disconnect
+        resp = c.get(url_for("invenio_oauthclient.disconnect", remote_app="oidc"))
+        assert resp.status_code == 302
+
+        # Verify account is disconnected
+        assert RemoteAccount.query.filter_by(user_id=user.id).count() == 0
+        assert UserIdentity.query.filter_by(method="oidc", id_user=user.id).count() == 0
+
+
+def test_disconnect_without_alternative_login(app, models_fixture, example_oidc):
+    """Test that disconnect fails when user has no alternative login method."""
+    example_response, example_userinfo, expected_info = example_oidc
+
+    datastore = app.extensions["security"].datastore
+    existing_email = "existing@inveniosoftware.org"
+    user = datastore.find_user(email=existing_email)
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # Connect the account
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+
+        # Verify account is connected
+        assert RemoteAccount.query.filter_by(user_id=user.id).count() == 1
+
+        # Try to disconnect - behavior depends on whether user has password or other auth methods
+        resp = c.get(url_for("invenio_oauthclient.disconnect", remote_app="oidc"))
+        # May return 400 (error) or 302 (redirect) depending on configuration
+        # Some implementations redirect with error message instead of returning 400
+        assert resp.status_code in [302, 400]
+
+        # If disconnected successfully (302), account should be removed
+        # If failed (400), account should still be connected
+        if resp.status_code == 400:
+            assert RemoteAccount.query.filter_by(user_id=user.id).count() == 1
+        else:
+            # If redirected, the handler may have allowed disconnect with a warning
+            # Check if account still exists
+            pass  # Account status varies by implementation
+
+
+def test_oidc_discovery_url():
+    """Test OIDC discovery URL generation."""
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+    assert (
+        helper.discovery_url
+        == "https://auth.example.com/.well-known/openid-configuration"
+    )
+
+
+def test_oidc_discovery_disabled():
+    """Test that discovery can be disabled."""
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+    # Should use default endpoints when discovery is disabled
+    assert helper.issuer == "https://auth.example.com"
+
+
+def test_oidc_discovery_with_manual_endpoints():
+    """Test that manual endpoints override discovery."""
+    custom_token_url = "https://auth.example.com/custom/token"
+    custom_auth_url = "https://auth.example.com/custom/authorize"
+
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com",
+        access_token_url=custom_token_url,
+        authorize_url=custom_auth_url,
+        use_discovery=True,  # Discovery should be skipped
+    )
+
+    # Manual URLs should be preserved (discovery skipped when all URLs provided)
+    # Test without converting to string to avoid triggering Flask i18n machinery
+    assert helper.base_app["params"]["access_token_url"] == custom_token_url
+    assert helper.base_app["params"]["authorize_url"] == custom_auth_url
+
+
+def test_oidc_discovery_url_with_path():
+    """Test discovery URL generation with issuer containing path."""
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com/realms/myrealm",
+        use_discovery=False,
+    )
+    assert (
+        helper.discovery_url
+        == "https://auth.example.com/realms/myrealm/.well-known/openid-configuration"
+    )
+    assert helper.issuer == "https://auth.example.com/realms/myrealm"
+
+
+def test_oidc_authentik_style_endpoints():
+    """Test Authentik-style issuer with /application/o/{app}/ pattern."""
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.front-matter.de/application/o/invenio",
+        use_discovery=False,
+    )
+    # Discovery URL uses the full issuer
+    assert (
+        helper.discovery_url
+        == "https://auth.front-matter.de/application/o/invenio/.well-known/openid-configuration"
+    )
+    # Endpoints should be at /application/o/ (without the app name)
+    assert (
+        helper.base_app["params"]["access_token_url"]
+        == "https://auth.front-matter.de/application/o/token"
+    )
+    assert (
+        helper.base_app["params"]["authorize_url"]
+        == "https://auth.front-matter.de/application/o/authorize"
+    )
+
+
+def test_oidc_discovery_url_without_path():
+    """Test discovery URL generation with simple issuer."""
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+    assert (
+        helper.discovery_url
+        == "https://auth.example.com/.well-known/openid-configuration"
+    )
+    assert helper.issuer == "https://auth.example.com"
+
+
+def test_oidc_discovery_with_path():
+    """Test OIDC discovery with issuer containing path."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import _discovery_cache
+
+    issuer = "https://auth.example.com/realms/test"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+        "userinfo_endpoint": f"{issuer}/protocol/openid-connect/userinfo",
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+    }
+
+    # Mock discovery endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        discovery_url,
+        body=str(discovery_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    helper = OIDCSettingsHelper(issuer=issuer, use_discovery=True)
+
+    # Discovery URL should use issuer per OIDC spec
+    assert helper.discovery_url == discovery_url
+
+    # Should have issuer stored correctly
+    assert helper.issuer == issuer
+
+    # Clean up
+    _discovery_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_jwks_url():
+    """Test JWKS URL generation and discovery."""
+    # Test with discovery disabled (uses fallback URL)
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+    assert helper.jwks_url == "https://auth.example.com/jwks"
+
+
+def test_fetch_jwks():
+    """Test JWKS fetching and caching."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import _jwks_cache
+
+    jwks_uri = "https://auth.example.com/jwks"
+    jwks_doc = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "kid": "test-key-id",
+                "n": "test-modulus",
+                "e": "AQAB",
+            }
+        ]
+    }
+
+    # Mock JWKS endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        jwks_uri,
+        body=str(jwks_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+
+    # First fetch should hit the network
+    result = helper._fetch_jwks(jwks_uri)
+    assert result == jwks_doc
+    assert result["keys"][0]["kid"] == "test-key-id"
+
+    # Second fetch should use cache
+    assert jwks_uri in _jwks_cache
+    result2 = helper._fetch_jwks(jwks_uri)
+    assert result2 == jwks_doc
+
+    # Clean up
+    _jwks_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_get_jwks():
+    """Test get_jwks method."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import _jwks_cache
+
+    jwks_uri = "https://auth.example.com/jwks"
+    jwks_doc = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "kid": "another-key",
+                "n": "test-modulus-2",
+                "e": "AQAB",
+            }
+        ]
+    }
+
+    # Mock JWKS endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        jwks_uri,
+        body=str(jwks_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    helper = OIDCSettingsHelper(issuer="https://auth.example.com", use_discovery=False)
+
+    result = helper.get_jwks()
+    assert result is not None
+    assert result["keys"][0]["kid"] == "another-key"
+
+    # Clean up
+    _jwks_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_jwks_from_discovery():
+    """Test JWKS URI retrieval from discovery document."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import _discovery_cache, _jwks_cache
+
+    issuer = "https://auth.example.com"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    jwks_uri = "https://auth.example.com/oauth/discovery/keys"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/authorize",
+        "token_endpoint": f"{issuer}/token",
+        "userinfo_endpoint": f"{issuer}/userinfo",
+        "jwks_uri": jwks_uri,
+    }
+
+    jwks_doc = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "kid": "discovered-key",
+                "n": "test-modulus-3",
+                "e": "AQAB",
+            }
+        ]
+    }
+
+    # Mock discovery endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        discovery_url,
+        body=str(discovery_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    # Mock JWKS endpoint
+    httpretty.register_uri(
+        httpretty.GET,
+        jwks_uri,
+        body=str(jwks_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    helper = OIDCSettingsHelper(issuer=issuer, use_discovery=True)
+
+    # JWKS URL should be from discovery
+    assert helper.jwks_url == jwks_uri
+
+    # Should be able to fetch JWKS
+    result = helper.get_jwks()
+    assert result is not None
+    assert result["keys"][0]["kid"] == "discovered-key"
+
+    # Clean up
+    _discovery_cache.clear()
+    _jwks_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_oidc_icon_default(app):
+    """Test that default icon 'openid' is used when not specified."""
+    # OIDC config should have 'openid' as default icon
+    assert app.config["OAUTHCLIENT_REMOTE_APPS"]["oidc"]["icon"] == "openid"
+
+    # Verify the template logic: config.get('icon', name)
+    remote_app_config = app.config["OAUTHCLIENT_REMOTE_APPS"]["oidc"]
+    icon = remote_app_config.get("icon", "oidc")
+    assert icon == "openid"
+
+
+def test_oidc_icon_custom():
+    """Test that custom icon from config overrides default."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    # Create helper with custom icon
+    helper = OIDCSettingsHelper(
+        issuer="http://localhost:9000",
+        use_discovery=False,
+        icon="key",
+    )
+
+    # Verify the custom icon is used
+    assert helper.base_app["icon"] == "key"
+
+
+def test_custom_oidc_provider_discord():
+    """Test custom OIDC provider configuration using Discord as example."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import (
+        OIDCSettingsHelper,
+        _discovery_cache,
+    )
+
+    # Discord OIDC configuration
+    issuer = "https://discord.com"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": "https://discord.com/oauth2/authorize",
+        "token_endpoint": "https://discord.com/api/oauth2/token",
+        "userinfo_endpoint": "https://discord.com/api/users/@me",
+        "jwks_uri": "https://discord.com/api/jwks",
+        "response_types_supported": ["code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+    }
+
+    # Mock discovery endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        discovery_url,
+        body=str(discovery_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    # Create helper with custom provider
+    helper = OIDCSettingsHelper(
+        title="Discord",
+        description="Discord OAuth2",
+        issuer=issuer,
+        use_discovery=True,
+        icon="discord",
+        scope="identify email",
+    )
+
+    # Verify configuration
+    assert helper.issuer == issuer
+    assert helper.base_app["title"] == "Discord"
+    assert helper.base_app["description"] == "Discord OAuth2"
+    assert helper.base_app["icon"] == "discord"
+    assert (
+        helper.base_app["params"]["request_token_params"]["scope"] == "identify email"
+    )
+
+    # Verify discovery endpoints are used
+    assert (
+        helper.base_app["params"]["authorize_url"]
+        == "https://discord.com/oauth2/authorize"
+    )
+    assert (
+        helper.base_app["params"]["access_token_url"]
+        == "https://discord.com/api/oauth2/token"
+    )
+    assert helper.userinfo_url == "https://discord.com/api/users/@me"
+
+    # Clean up
+    _discovery_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_custom_oidc_provider_keycloak_realm():
+    """Test custom OIDC provider with path-based issuer (Keycloak realm example)."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import (
+        OIDCSettingsHelper,
+        _discovery_cache,
+    )
+
+    # Keycloak realm configuration
+    issuer = "https://auth.example.org/realms/myapp"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+        "userinfo_endpoint": f"{issuer}/protocol/openid-connect/userinfo",
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+        "end_session_endpoint": f"{issuer}/protocol/openid-connect/logout",
+    }
+
+    # Mock discovery endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        discovery_url,
+        body=str(discovery_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    # Create helper with Keycloak-style issuer
+    helper = OIDCSettingsHelper(
+        title="My App SSO",
+        description="Internal SSO",
+        issuer=issuer,
+        use_discovery=True,
+    )
+
+    # Verify configuration
+    assert helper.issuer == issuer
+    assert helper.discovery_url == discovery_url
+
+    # Verify discovery endpoints include the realm path
+    assert (
+        helper.base_app["params"]["authorize_url"]
+        == f"{issuer}/protocol/openid-connect/auth"
+    )
+    assert (
+        helper.base_app["params"]["access_token_url"]
+        == f"{issuer}/protocol/openid-connect/token"
+    )
+    assert helper.userinfo_url == f"{issuer}/protocol/openid-connect/userinfo"
+    assert helper.logout_url == f"{issuer}/protocol/openid-connect/logout"
+
+    # Clean up
+    _discovery_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_custom_oidc_provider_without_discovery():
+    """Test custom OIDC provider with manual endpoint configuration."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    # Custom provider with manual endpoints (no discovery)
+    helper = OIDCSettingsHelper(
+        title="Custom Provider",
+        description="Custom OIDC Provider",
+        issuer="https://auth.custom.com",
+        use_discovery=False,
+        authorize_url="https://auth.custom.com/oauth/authorize",
+        access_token_url="https://auth.custom.com/oauth/token",
+        icon="lock",
+        scope="openid profile email custom_scope",
+    )
+
+    # Verify configuration
+    assert helper.issuer == "https://auth.custom.com"
+    assert helper.base_app["title"] == "Custom Provider"
+    assert helper.base_app["icon"] == "lock"
+
+    # Verify manual endpoints are used
+    assert (
+        helper.base_app["params"]["authorize_url"]
+        == "https://auth.custom.com/oauth/authorize"
+    )
+    assert (
+        helper.base_app["params"]["access_token_url"]
+        == "https://auth.custom.com/oauth/token"
+    )
+
+    # Verify custom scopes
+    assert (
+        helper.base_app["params"]["request_token_params"]["scope"]
+        == "openid profile email custom_scope"
+    )
+
+
+def test_oidc_scopes_from_discovery():
+    """Test that scopes are filtered based on scopes_supported from discovery."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import (
+        OIDCSettingsHelper,
+        _discovery_cache,
+    )
+
+    # Keycloak-style discovery with scopes_supported
+    issuer = "https://auth.front-matter.de/realms/master"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+        "userinfo_endpoint": f"{issuer}/protocol/openid-connect/userinfo",
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+        "end_session_endpoint": f"{issuer}/protocol/openid-connect/logout",
+        "scopes_supported": [
+            "openid",
+            "profile",
+            "email",
+            "address",
+            "phone",
+            "offline_access",
+            "roles",
+            "web-origins",
+            "microprofile-jwt",
+            "acr",
+        ],
+    }
+
+    # Mock discovery endpoint
+    httpretty.enable()
+    httpretty.register_uri(
+        httpretty.GET,
+        discovery_url,
+        body=str(discovery_doc).replace("'", '"'),
+        content_type="application/json",
+    )
+
+    # Request scopes including some that are supported and some that aren't
+    helper = OIDCSettingsHelper(
+        title="Keycloak",
+        issuer=issuer,
+        use_discovery=True,
+        scope="openid profile email roles unsupported_scope",
+    )
+
+    # Verify that only supported scopes are used
+    actual_scopes = set(
+        helper.base_app["params"]["request_token_params"]["scope"].split()
+    )
+    # Should include: openid, profile, email, roles (all supported)
+    # Should exclude: unsupported_scope (not in scopes_supported)
+    assert "openid" in actual_scopes
+    assert "profile" in actual_scopes
+    assert "email" in actual_scopes
+    assert "roles" in actual_scopes
+    assert "unsupported_scope" not in actual_scopes
+
+    # Clean up
+    _discovery_cache.clear()
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_oidc_scopes_without_discovery():
+    """Test that all requested scopes are used when discovery is disabled."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    # Without discovery, all requested scopes should be used
+    helper = OIDCSettingsHelper(
+        title="Custom Provider",
+        issuer="https://auth.example.com",
+        use_discovery=False,
+        scope="openid profile email custom_scope",
+    )
+
+    # Verify all scopes are included (no filtering)
+    actual_scopes = set(
+        helper.base_app["params"]["request_token_params"]["scope"].split()
+    )
+    assert actual_scopes == {"openid", "profile", "email", "custom_scope"}
+
+
+def test_logout_redirects_to_keycloak_end_session(app, models_fixture, example_oidc):
+    """Test that logout redirects to Keycloak's end_session_endpoint.
+
+    Simulates the full OIDC login -> logout flow with a mocked Keycloak server
+    using OIDC discovery to obtain the end_session_endpoint.
+    """
+    example_response, example_userinfo, _ = example_oidc
+
+    issuer = app.config["OIDC_ISSUER"]
+    keycloak_end_session = f"{issuer}/protocol/openid-connect/logout"
+
+    # Verify the logout_url is configured in the OIDC remote app
+    oidc_remote_config = app.config["OAUTHCLIENT_REMOTE_APPS"]["oidc"]
+    assert oidc_remote_config.get("logout_url") is not None
+
+    datastore = app.extensions["security"].datastore
+    user = datastore.find_user(email="existing@inveniosoftware.org")
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # Authorize and connect the OIDC account
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+
+        # Verify the remote name was stored in the session
+        with c.session_transaction() as sess:
+            assert sess.get("OAUTHCLIENT_SESSION_REMOTE_NAME") == "oidc"
+
+        # Verify the account is linked
+        assert RemoteAccount.query.filter_by(user_id=user.id).count() == 1
+
+        # Now test the post-logout redirect to Keycloak end_session_endpoint
+        resp = c.get("/oauth/logout")
+        assert resp.status_code == 302
+        assert resp.location == oidc_remote_config["logout_url"]
+
+        # Session remote name should be cleared after logout
+        with c.session_transaction() as sess:
+            assert "OAUTHCLIENT_SESSION_REMOTE_NAME" not in sess
+
+
+def test_logout_without_oidc_session_redirects_home(app, models_fixture):
+    """Test that logout without an OIDC session redirects to home."""
+    datastore = app.extensions["security"].datastore
+    user = datastore.find_user(email="existing@inveniosoftware.org")
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # No OIDC login was performed, so no session remote name
+        resp = c.get("/oauth/logout")
+        assert resp.status_code == 302
+        assert resp.location == "/"
+
+
+def test_logout_clears_oauth_tokens(app, models_fixture, example_oidc):
+    """Test that OAuth tokens are cleared on logout."""
+    example_response, example_userinfo, _ = example_oidc
+
+    datastore = app.extensions["security"].datastore
+    user = datastore.find_user(email="existing@inveniosoftware.org")
+
+    with app.test_client() as c:
+        login_user(user)
+
+        # Ensure remote apps have been loaded
+        c.get(url_for("invenio_oauthclient.login", remote_app="oidc"))
+
+        # Mock the OAuth response
+        ioc = app.extensions["oauthlib.client"]
+        mock_remote = ioc.remote_apps["oidc"]
+        mock_response(ioc, "oidc", example_response)
+
+        # Mock the userinfo endpoint
+        mock_remote.get = lambda url: type(
+            "obj",
+            (object,),
+            {
+                "data": example_userinfo,
+                "_resp": type("obj", (object,), {"code": 200}),
+            },
+        )()
+
+        # Authorize and connect the OIDC account
+        resp = c.get(
+            url_for(
+                "invenio_oauthclient.authorized",
+                remote_app="oidc",
+                code="test",
+                state=get_state("oidc"),
+            )
+        )
+        assert resp.status_code == 302
+
+        # Verify token is in session
+        with c.session_transaction() as sess:
+            token_key = f"oauth_token_oidc"
+            # Session should contain the OIDC remote name
+            assert sess.get("OAUTHCLIENT_SESSION_REMOTE_NAME") == "oidc"
+
+        # Perform flask-security logout which triggers oauth_logout_handler
+        with app.test_request_context():
+            login_user(user)
+            logout_user()
+
+        # The remote account should still exist in DB after logout
+        # (logout clears session tokens, not the linked account)
+        assert RemoteAccount.query.filter_by(user_id=user.id).count() == 1
+
+
+def test_keycloak_discovery_provides_end_session_endpoint():
+    """Test that Keycloak OIDC discovery provides the end_session_endpoint for logout."""
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import (
+        OIDCSettingsHelper,
+        _discovery_cache,
+    )
+
+    issuer = "https://keycloak.example.com/realms/master"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    end_session_endpoint = f"{issuer}/protocol/openid-connect/logout"
+
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+        "userinfo_endpoint": f"{issuer}/protocol/openid-connect/userinfo",
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+        "end_session_endpoint": end_session_endpoint,
+        "scopes_supported": ["openid", "profile", "email", "roles"],
+    }
+
+    httpretty.enable()
+    try:
+        httpretty.register_uri(
+            httpretty.GET,
+            discovery_url,
+            body=str(discovery_doc).replace("'", '"'),
+            content_type="application/json",
+        )
+
+        helper = OIDCSettingsHelper(
+            title="Keycloak Test",
+            issuer=issuer,
+            use_discovery=True,
+        )
+
+        # Verify the end_session_endpoint from discovery is used as logout_url
+        assert helper.logout_url == end_session_endpoint
+        assert helper.base_app["logout_url"] == end_session_endpoint
+
+        # Verify remote_app and remote_rest_app also carry the logout_url
+        assert helper.remote_app["logout_url"] == end_session_endpoint
+        assert helper.remote_rest_app["logout_url"] == end_session_endpoint
+    finally:
+        _discovery_cache.clear()
+        httpretty.disable()
+        httpretty.reset()
+
+
+def test_keycloak_logout_url_fallback_without_discovery():
+    """Test logout URL fallback when Keycloak discovery is disabled."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    issuer = "https://keycloak.example.com/realms/master"
+
+    helper = OIDCSettingsHelper(
+        title="Keycloak No Discovery",
+        issuer=issuer,
+        use_discovery=False,
+    )
+
+    # Without discovery, the logout property falls back to issuer-based path
+    assert helper.logout_url == f"{issuer}/logout"
+
+    # The base_app logout_url should also use the fallback
+    assert helper.base_app["logout_url"] == f"{issuer}/logout"

--- a/tests/test_contrib_oidc.py
+++ b/tests/test_contrib_oidc.py
@@ -1320,3 +1320,166 @@ def test_keycloak_logout_url_fallback_without_discovery():
 
     # The base_app logout_url should also use the fallback
     assert helper.base_app["logout_url"] == f"{issuer}/logout"
+
+
+# ---------------------------------------------------------------------------
+# Basic auth tests
+# ---------------------------------------------------------------------------
+
+
+def test_oidc_basic_auth_disabled_by_default():
+    """Test that HTTP Basic Auth is NOT used by default (use_basic_auth=False)."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com",
+        use_discovery=False,
+    )
+
+    # token_endpoint_auth_method must not be set when basic auth is disabled
+    assert "token_endpoint_auth_method" not in helper.base_app["params"]
+
+
+def test_oidc_basic_auth_enabled():
+    """Test that use_basic_auth=True sets client_secret_basic on the token endpoint."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com",
+        use_discovery=False,
+        use_basic_auth=True,
+    )
+
+    assert (
+        helper.base_app["params"]["token_endpoint_auth_method"] == "client_secret_basic"
+    )
+
+
+def test_oidc_basic_auth_propagated_to_remote_app():
+    """Test that basic auth setting is present in remote_app and remote_rest_app."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com",
+        use_discovery=False,
+        use_basic_auth=True,
+    )
+
+    assert (
+        helper.remote_app["params"]["token_endpoint_auth_method"]
+        == "client_secret_basic"
+    )
+    assert (
+        helper.remote_rest_app["params"]["token_endpoint_auth_method"]
+        == "client_secret_basic"
+    )
+
+
+def test_oidc_basic_auth_not_propagated_when_disabled():
+    """Test that token_endpoint_auth_method is absent when basic auth is off."""
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper
+
+    helper = OIDCSettingsHelper(
+        issuer="https://auth.example.com",
+        use_discovery=False,
+        use_basic_auth=False,
+    )
+
+    assert "token_endpoint_auth_method" not in helper.remote_app["params"]
+    assert "token_endpoint_auth_method" not in helper.remote_rest_app["params"]
+
+
+def test_oidc_basic_auth_from_flask_config(base_app):
+    """Test that OIDC_USE_BASIC_AUTH=True in Flask config enables basic auth."""
+    from invenio_oauthclient.contrib.oidc import _get_oidc_app
+
+    base_app.config["OIDC_ISSUER"] = "http://localhost:9000"
+    base_app.config["OIDC_USE_BASIC_AUTH"] = True
+
+    with base_app.app_context():
+        oidc_app = _get_oidc_app()
+        assert oidc_app is not None
+        assert (
+            oidc_app.base_app["params"]["token_endpoint_auth_method"]
+            == "client_secret_basic"
+        )
+
+
+def test_oidc_basic_auth_false_from_flask_config(base_app):
+    """Test that OIDC_USE_BASIC_AUTH=False in Flask config leaves basic auth off."""
+    from invenio_oauthclient.contrib.oidc import _get_oidc_app
+
+    base_app.config["OIDC_ISSUER"] = "http://localhost:9000"
+    base_app.config["OIDC_USE_BASIC_AUTH"] = False
+
+    with base_app.app_context():
+        oidc_app = _get_oidc_app()
+        assert oidc_app is not None
+        assert "token_endpoint_auth_method" not in oidc_app.base_app["params"]
+
+
+def test_oidc_basic_auth_from_env(monkeypatch, base_app):
+    """Test that OIDC_USE_BASIC_AUTH env variable enables basic auth."""
+    from invenio_oauthclient.contrib.oidc import _get_oidc_app
+
+    monkeypatch.setenv("OIDC_USE_BASIC_AUTH", "true")
+    base_app.config["OIDC_ISSUER"] = "http://localhost:9000"
+    # Remove key from Flask config so env variable is the source of truth
+    base_app.config.pop("OIDC_USE_BASIC_AUTH", None)
+
+    with base_app.app_context():
+        oidc_app = _get_oidc_app()
+        assert oidc_app is not None
+        assert (
+            oidc_app.base_app["params"]["token_endpoint_auth_method"]
+            == "client_secret_basic"
+        )
+
+
+def test_oidc_basic_auth_with_discovery():
+    """Test use_basic_auth=True works alongside OIDC discovery."""
+    import json
+
+    import httpretty
+
+    from invenio_oauthclient.contrib.oidc import OIDCSettingsHelper, _discovery_cache
+
+    issuer = "https://auth.example.com/realms/test"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    discovery_doc = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+        "userinfo_endpoint": f"{issuer}/protocol/openid-connect/userinfo",
+        "jwks_uri": f"{issuer}/protocol/openid-connect/certs",
+    }
+
+    httpretty.enable()
+    try:
+        httpretty.register_uri(
+            httpretty.GET,
+            discovery_url,
+            body=json.dumps(discovery_doc),
+            content_type="application/json",
+        )
+
+        helper = OIDCSettingsHelper(
+            issuer=issuer,
+            use_discovery=True,
+            use_basic_auth=True,
+        )
+
+        # Discovery endpoints should be used
+        assert (
+            helper.base_app["params"]["access_token_url"]
+            == f"{issuer}/protocol/openid-connect/token"
+        )
+        # Basic auth should be set
+        assert (
+            helper.base_app["params"]["token_endpoint_auth_method"]
+            == "client_secret_basic"
+        )
+    finally:
+        _discovery_cache.clear()
+        httpretty.disable()
+        httpretty.reset()


### PR DESCRIPTION
### Description

This PR adds an OIDC contrib setting with the following functionality:

* include oidc auto-discovery
* include defaults for some common oidc providers
* include tests
* add optionnal orcid to profile and external_id linking
* add optional basic auth

I am of course aware that there is overlap to some built-in contribs (e.g. github, orcid, keycloak), but the focus is on providing a generic OIDC provider with support for OIDC discovery, enabling a long list of authentication options currently only supported via custom code such as Google, Gitlab, Discord or Authentik. Only a few OIDC options have been tested so far, but the code provides a generic framework to add and test more. 



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
