### PR TITLE
fix: bad downstream dependency in alembic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@
 Changes
 =======
 
+Version v8.0.0 (released 2026-05-28)
+
+- chore(setup): bump dependencies
+- fix: bad downstream dependency in alembic
+- fix(ui): reorder menu in user settings
+
 Version v7.0.1 (released 2026-05-13)
 
 - fix(logout): remove unmanage_roles from session

--- a/invenio_oauthclient/__init__.py
+++ b/invenio_oauthclient/__init__.py
@@ -14,7 +14,7 @@ from .ext import InvenioOAuthClient, InvenioOAuthClientREST
 from .oauth import oauth_link_external_id, oauth_unlink_external_id
 from .proxies import current_oauthclient
 
-__version__ = "7.0.1"
+__version__ = "8.0.0"
 
 __all__ = (
     "__version__",

--- a/invenio_oauthclient/alembic/44ab9963e8cf_create_oauthclient_branch.py
+++ b/invenio_oauthclient/alembic/44ab9963e8cf_create_oauthclient_branch.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "44ab9963e8cf"
-down_revision = "dbdbc1b19cf2"
+down_revision = None
 branch_labels = ("invenio_oauthclient",)
 depends_on = "dbdbc1b19cf2"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ zip_safe = False
 install_requires =
     blinker>=1.4
     Flask-OAuthlib-Invenio>=2.0.0,<3.0.0
-    invenio-accounts>=7.0.0,<8.0.0
+    invenio-accounts>=8.0.0,<9.0.0
     invenio-base>=2.0.0,<3.0.0
     invenio-i18n>=3.0.0,<4.0.0
     invenio-mail>=1.0.2,<3.0.0
@@ -46,7 +46,7 @@ tests =
     flask_admin>=1.6.0
     pytest-black>=0.6.0
     httpretty>=0.8.14
-    invenio-userprofiles>=5.0.0,<6.0.0
+    invenio-userprofiles>=6.0.0,<7.0.0
     mock>=1.3.0
     oauthlib>=1.1.2
     pytest-invenio>=4.0.0,<5.0.0
@@ -55,7 +55,7 @@ tests =
     sphinx>=4.5
     invenio-db[mysql,postgresql,versioning]>=2.2.0,<3.0.0
 admin =
-    invenio-accounts[admin]>=7.0.0,<8.0.0
+    invenio-accounts[admin]>=8.0.0,<9.0.0
 
 # Kept for backwards compatibility
 docs =

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015-2020 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+
+"""Alembic upgrade tests."""
+
+import pytest
+from invenio_db import db
+
+
+def test_alembic(app):
+    """Test alembic recipes."""
+    ext = app.extensions["invenio-db"]
+
+    with app.app_context():
+        if db.engine.name == "sqlite":
+            raise pytest.skip("Upgrades are not supported on SQLite.")
+
+        assert not ext.alembic.compare_metadata()
+        db.drop_all()
+        ext.alembic.upgrade()
+
+        assert not ext.alembic.compare_metadata()
+        ext.alembic.downgrade(target="44ab9963e8cf")
+        ext.alembic.upgrade()
+
+        assert not ext.alembic.compare_metadata()
+        ext.alembic.downgrade(target="44ab9963e8cf")


### PR DESCRIPTION
### Description

* The initial migration was generated with invenio-db as a downstream, which creates multiple "default" heads, disrupting alembic revision
* The fix is to use plain depends_on instead of downstream revision
* Tests for upgrade/downgrade added


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
